### PR TITLE
PP-5012 Slugify Welsh diactritics

### DIFF
--- a/src/nunjucks-filters/slugify.js
+++ b/src/nunjucks-filters/slugify.js
@@ -1,6 +1,24 @@
 const slugify = require('slugify')
 
 module.exports = string => {
+  slugify.extend({
+    ŵ: 'w',
+    ẁ: 'w',
+    ẃ: 'w',
+    ẅ: 'w',
+    ŷ: 'y',
+    ỳ: 'y',
+    ý: 'y',
+    ÿ: 'y',
+    Ŵ: 'W',
+    Ẁ: 'W',
+    Ẃ: 'W',
+    Ẅ: 'W',
+    Ŷ: 'Y',
+    Ỳ: 'Y',
+    Ý: 'Y',
+    Ÿ: 'Y'
+  })
   return slugify(
     string,
     {

--- a/src/nunjucks-filters/slugify.test.js
+++ b/src/nunjucks-filters/slugify.test.js
@@ -7,4 +7,12 @@ describe('When a string is passed through the Nunjucks slugify filter', () => {
   it('it should make it url friendly', () => {
     expect(slugify('Someones’s string')).to.equal('someoness-string')
   })
+
+  it('should replace all Welsh accented vowels with unaccented characters', () => {
+    expect(slugify('îïìíûùúüêèéëâàáäæåãôòóöœøyŷỳýÿŵẁẃẅ')).to.equal('iiiiuuuueeeeaaaaaeaaoooooeoyyyyywwww')
+  })
+
+  it('should replace capital Welsh accented vowels with lower case unaccented characters', () => {
+    expect(slugify('ÎÏÌÍÛÙÚÜÊÈÉËÂÀÁÄÆÅÃÔÒÓÖŒØŶỲÝŸŴẀẂẄ')).to.equal('iiiiuuuueeeeaaaaaeaaoooooeoyyyywwww')
+  })
 })


### PR DESCRIPTION
Extend slugify to convert diacritics used in Welsh which are not
included by default

Co-Authored-By Yancoba Thompson <yancoba.thompson@digital.cabinet-office.gov.uk>