### PR TITLE
PP-5764 Add environment field to logs

### DIFF
--- a/src/logging/format.js
+++ b/src/logging/format.js
@@ -6,6 +6,7 @@ const govUkPayLoggingFormat = format((info, opts) => {
   info['@timestamp'] = new Date().toISOString()
   info['@version'] = 1
   info.container = opts.container
+  info.environment = opts.environment
   info.level = info.level.toUpperCase()
   return info
 })


### PR DESCRIPTION
Add an 'environment' field to the logs, so that it is possible to filter
by environment using a Splunk text search. Splunk does currently extract
the environment from the source if it is explicitly searched on using
e.g. the term 'environment="production-2"', but some of our reports use
a text search so will not pick up on all log lines.

The text search continues to work for many logs where the environment is
included in some way in the log message, but not for others where it
isn't so it makes sense to get rid of this ambiguity.

In the apps producing the logs, we get the environment from an
environment variable which is already configured for use by Sentry.