### PR TITLE
PP-5762 Log correlation id for incoming requests

### DIFF
--- a/src/logging/request-log-format.js
+++ b/src/logging/request-log-format.js
@@ -1,18 +1,21 @@
-const requestLogFormat = (tokens, req, res) => {
-  return JSON.stringify({
-    /* eslint-disable camelcase */
-    remote_address: tokens['remote-addr'](req, res),
-    remote_user: tokens['remote-user'](req, res),
-    method: tokens.method(req, res),
-    url: tokens.url(req, res),
-    http_version: tokens['http-version'](req, res),
-    status_code: tokens.status(req, res),
-    content_length: tokens.res(req, res, 'content-length'),
-    referrer: tokens.referrer(req, res),
-    user_agent: tokens['user-agent'](req, res),
-    response_time: `${tokens['response-time'](req, res)} ms`
-    /* eslint-enable camelcase */
-  })
-}
+module.exports = (correlationIdHeader = 'x-request-id') => {
+  const format = (tokens, req, res) => {
+    return JSON.stringify({
+      /* eslint-disable camelcase */
+      remote_address: tokens['remote-addr'](req, res),
+      remote_user: tokens['remote-user'](req, res),
+      method: tokens.method(req, res),
+      url: tokens.url(req, res),
+      http_version: tokens['http-version'](req, res),
+      status_code: tokens.status(req, res),
+      content_length: tokens.res(req, res, 'content-length'),
+      referrer: tokens.referrer(req, res),
+      user_agent: tokens['user-agent'](req, res),
+      response_time: `${tokens['response-time'](req, res)} ms`,
+      x_request_id: tokens.req(req, res, correlationIdHeader)
+      /* eslint-enable camelcase */
+    })
+  }
 
-module.exports = { requestLogFormat }
+  return { format }
+}


### PR DESCRIPTION
Add a field in the format we provide to morgan for logging to log the
correlation id. Modify the class so that it takes a parameter providing
it with the name of the correlation id header for the app.