### PR TITLE
PP-5762 Fix export for request log format

### DIFF
--- a/src/logging/index.js
+++ b/src/logging/index.js
@@ -2,6 +2,6 @@
 
 const keys = require('./keys')
 const { govUkPayLoggingFormat } = require('./format')
-const { requestLogFormat } = require('./request-log-format')
+const requestLogFormat = require('./request-log-format')
 
 module.exports = { govUkPayLoggingFormat, keys, requestLogFormat }


### PR DESCRIPTION
How we do the export in `request-log-format.js` changed, but the require in `logging/index.js` wasn't updated. This fixes this.