### PR TITLE
Bump version to 2.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
- Bump version to 2.23.0 to publish for custom branding https://github.com/alphagov/pay-js-commons/pull/267