### PR TITLE
BAU: Allow self-updating Concourse pipelines

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -10,10 +10,19 @@ resources:
 
     - name: pull-request
       type: pull-request
+      icon: github
       source:
         repository: alphagov/pay-js-commons
         access_token: ((github-access-token))
 
+    - name: pipeline
+      type: git
+      icon: github
+      source:
+        uri: https://github.com/alphagov/pay-js-commons
+        branch: master
+        paths:
+          - ci/pipeline.yml
 jobs:
   - name: build-pr
     serial: true
@@ -56,3 +65,10 @@ jobs:
         params:
           path: pull-request
           status: success
+
+  - name: update-pipeline
+    plan:
+      - get: pipeline
+        trigger: true
+      - set_pipeline: pay-js-commons
+        file: pipeline/ci/pipeline.yml


### PR DESCRIPTION
Allows changes to pipeline to be auto deployed on merge. Users do not need to set the pipeline changes themselves.