### PR TITLE
zd4195581: Right align Adur&Worthing borough logo

### DIFF
--- a/sass/custom/adur-and-worthing-council.scss
+++ b/sass/custom/adur-and-worthing-council.scss
@@ -46,6 +46,10 @@ $logo-image-height: 2em;
       vertical-align: bottom;
       margin-bottom: 7px;
     }
+    .govuk-header__link--service-name {
+      padding-top: 15px;
+      float: right;
+    }
   }
 
   .govuk-button {


### PR DESCRIPTION
Fixes this
<img width="810" alt="Screenshot 2020-08-19 at 10 27 22" src="https://user-images.githubusercontent.com/9698354/90617419-907cca80-e206-11ea-835d-408856317b1f.png">
