### PR TITLE
PP-6284 enable analytics with consent banner

### DIFF
--- a/src/analytics/cookies/banner.html
+++ b/src/analytics/cookies/banner.html
@@ -1,7 +1,131 @@
 <style>
-	/* TODO */
-	.pay-cookie-banner{
+	/* component should only be shown if JS is available, by the cookieMessage JS, so hide by default */
+	.pay-cookie-banner {
+		display: block;
+	}
+
+	.pay-cookie-banner__wrapper {
+		padding-top: 15px;
+    	padding-bottom: 15px;
+	}
+
+	.pay-cookie-banner__buttons {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	@media (min-width: 40.0625em){
+		.pay-cookie-banner__buttons {
+			flex-wrap: nowrap;
+		}
+	}
+
+
+	.pay-cookie-banner__button,
+	.pay-cookie-banner__link {
+		vertical-align: baseline;
+	}
+
+	.pay-cookie-banner__button {
+		display: inline-block;
+		flex: 1 0;
+		padding-left: 60px;
+		padding-right: 60px;
+		margin-bottom: 10px;
+		margin-right: 20px;
+	}
+
+	@media (min-width: 40.0625em){
+		.pay-cookie-banner__button {
+			flex: 0 0 150px;
+			padding-left: 10px;
+			padding-right: 10px;
+			margin-bottom: 5px;
+		}
+	}
+	
+	.pay-cookie-banner__link {
+		font-family: "GDS Transport", Arial, sans-serif;
+		font-weight: 400;
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25;
+		line-height: 1;
+		display: block;
+		width: 100%;
+	    padding: 9px 0px 6px;
+	}
+	
+	@media (min-width: 40.0625em){
+		.pay-cookie-banner__link {
+			display: inline;
+			width: auto;
+			margin-left: 30px;
+		}
+	}
+
+
+	.pay-cookie-banner__confirmation {
+		display: none;
+		position: relative;
+		padding: 20px 0;
+
 		
+	}
+
+	/* This element is focused using JavaScript so that it's being read out by screen readers
+	or this reason we don't want to show the default outline or emphasise it visually using `govuk-focused-text`*/
+	.pay-cookie-banner__confirmation:focus {
+	    outline: none;
+	}
+
+
+	.pay-cookie-banner__confirmation-message,
+	.pay-cookie-banner__hide-button {
+		display: block;
+	}
+
+
+	@media (min-width: 48.0625em){
+		.pay-cookie-banner__confirmation-message, 
+		.pay-cookie-banner__hide-button {
+		    display: inline-block;
+		}
+	}
+
+	.pay-cookie-banner__confirmation-message {
+		margin-right: 20px;
+	}
+
+	@media (min-width: 48.0625em){
+		.pay-cookie-banner__confirmation-message {
+			max-width: 90%;
+		}
+	}
+
+	.pay-cookie-banner__hide-button {
+		font-family: "GDS Transport", Arial, sans-serif;
+		font-weight: 400;
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25;
+		color: #1d70b8;
+		outline: 0;
+		border: 0;
+		background: none;
+		text-decoration: underline;
+		padding: 0;
+		margin-top: 10px;
+		right: 15px;
+		cursor: pointer;
+	}
+
+	@media (min-width: 40.0625em){
+		.pay-cookie-banner__hide-button {
+			font-size: 19px;
+			font-size: 1.1875rem;
+			line-height: 1.3157894737;
+		}
 	}
 </style>
 <div id="pay-cookie-banner" class="pay-cookie-banner govuk-width-container" data-module="pay-cookie-banner" role="region" aria-describedby="pay-cookie-banner__heading">
@@ -25,7 +149,7 @@
 
 	<div class="pay-cookie-banner__confirmation" tabindex="-1">
 		<p class="pay-cookie-banner__confirmation-message govuk-body">
-			You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.
+			You can <a class="govuk-link" href="https://www.payments.service.gov.uk/cookies/">change your cookie settings</a> at any time.
 		</p>
 		<button class="pay-cookie-banner__hide-button govuk-link" data-hide-cookie-banner="true" role="link">Hide</button>
 	</div>

--- a/src/analytics/cookies/validate.js
+++ b/src/analytics/cookies/validate.js
@@ -31,21 +31,49 @@ function setAnalyticsCookie(userConsentedToAnalytics = false) {
   Cookies.set(GOVUK_PAY_ANALYTICS_CONSENT_COOKIE_NAME, cookieValue, cookieAttributes)
 }
 
-function hideBannerIfExists() {
+function hideBannerIfExists(event) {
   const banner = document.querySelector(`#${ANALYTICS_CONSENT_BANNER_ID}`)
   if (banner) {
     banner.style.display = 'none'
   }
+
+  if (event.target) {
+    event.preventDefault();
+  }
 }
+
+function showConfirmationMessage (analyticsConsent) {
+  var messagePrefix = analyticsConsent
+    ? "You’ve accepted analytics cookies."
+    : "You told us not to use analytics cookies.";
+
+  var $cookieBannerMainContent = document.querySelector(
+    ".pay-cookie-banner__wrapper"
+  );
+
+  var $cookieBannerConfirmationMessage = document.querySelector(
+    ".pay-cookie-banner__confirmation-message"
+  );
+  
+  $cookieBannerConfirmationMessage.insertAdjacentText(
+    "afterbegin",
+    messagePrefix
+  );
+
+  $cookieBannerMainContent.style.display = "none";
+
+  var $cookieBannerConfirmationWrapper = document.querySelector(".pay-cookie-banner__confirmation") 
+  $cookieBannerConfirmationWrapper.style.display = "block";
+};
 
 function acceptAnalyticsCookies() {
   setAnalyticsCookie(true)
-  hideBannerIfExists()
+  showConfirmationMessage(true)
 }
 
 function rejectAnalyticsCookies() {
   setAnalyticsCookie(false)
-  hideBannerIfExists()
+  showConfirmationMessage(false)
 }
 
 function createBannerHTMLElement(consentProvidedCallback = () => {}) {
@@ -61,6 +89,12 @@ function createBannerHTMLElement(consentProvidedCallback = () => {}) {
     acceptButton.addEventListener('click', consentProvidedCallback)
     rejectButton.addEventListener('click', rejectAnalyticsCookies)
   }
+
+  const hideCookieBannerLink = banner.querySelector('button[data-hide-cookie-banner]')
+
+  if (hideCookieBannerLink) {
+    hideCookieBannerLink.addEventListener('click', hideBannerIfExists)
+  } 
 
   return banner
 }

--- a/src/analytics/cookies/validate.test.js
+++ b/src/analytics/cookies/validate.test.js
@@ -76,8 +76,60 @@ describe("Cookie Banner", () => {
       expect(
         mockFunction.mock.calls.length
       ).toBe(0);
+    })
+
+    it(`click YES on the cookie banner - displays confirmation message`, () => {
+        const mockFunction = jest.fn()  
+        validate.showBannerIfConsentNotSet(mockFunction) 
+      
+        document.querySelector("button[data-accept-cookies=true]").click();
+  
+        const confirmBanner = document.querySelector(
+          ".pay-cookie-banner__confirmation"
+        );
+
+        expect(confirmBanner.style.display).toEqual("block");
+        
+        expect(
+          mockFunction.mock.calls.length
+        ).toBe(1);
+      });
+
+    it(`click NO on the cookie banner - displays confirmation message`, () => {
+      const mockFunction = jest.fn()  
+      validate.showBannerIfConsentNotSet(mockFunction) 
+    
+      document.querySelector("button[data-accept-cookies=false]").click();
+
+      const confirmBanner = document.querySelector(
+        ".pay-cookie-banner__confirmation"
+      );
+
+      expect(confirmBanner.style.display).toEqual("block");
+      
+      expect(
+        mockFunction.mock.calls.length
+      ).toBe(0);
+    });
   })
-  })
+
+  describe("Confirmation mesage", () => {
+      it(`hide button works`, () => {
+      validate.showBannerIfConsentNotSet() 
+    
+      document.querySelector("button[data-accept-cookies=true]").click();
+
+      const confirmBanner = document.querySelector(
+        ".pay-cookie-banner__confirmation"
+      );
+
+      expect(confirmBanner.style.display).toEqual("block");
+
+      confirmBanner.querySelector(".pay-cookie-banner__hide-button").click();
+      const banner = document.querySelector('#pay-cookie-banner')
+      expect(banner.style.display).toEqual("none");
+    });
+  });
 
   describe("hasAnalyticsConsent", () => {
     it(`return FALSE when no cookie present`, () => {
@@ -100,47 +152,4 @@ describe("Cookie Banner", () => {
       expect(hasAnalyticsConsent).toEqual(false);
     });
   })
-
-  // TODO - Need to add confirmation message and then reinstate tests below
-
-  // describe("New User", () => {
-
-  //   it(`click YES on the cookie banner - displays confirmation message`, () => {
-  //     window.GovUkPay.CookieBanner.checkForBannerAndInit();
-  //     document.querySelector("button[data-accept-cookies=true]").click();
-
-  //     const confirmBanner = document.querySelector(
-  //       ".pay-cookie-banner__confirmation"
-  //     );
-  //     expect(confirmBanner.style.display).toEqual("block");
-  //     expect(
-  //       window.GovUkPay.InitAnalytics.InitialiseAnalytics.mock.calls.length
-  //     ).toBe(1);
-  //   });
-
-  //   it(`click NO on the cookie banner - displays confirmation message`, () => {
-  //     window.GovUkPay.CookieBanner.checkForBannerAndInit();
-  //     document.querySelector("button[data-accept-cookies=false]").click();
-
-  //     const confirmBanner = document.querySelector(
-  //       ".pay-cookie-banner__confirmation"
-  //     );
-  //     expect(confirmBanner.style.display).toEqual("block");
-  //   });
-  // });
-
-  // describe("Confirmation mesage", () => {
-  //   it(`hide button works`, () => {
-  //     window.GovUkPay.CookieBanner.checkForBannerAndInit();
-  //     document.querySelector("button[data-accept-cookies=true]").click();
-
-  //     const confirmBanner = document.querySelector(
-  //       ".pay-cookie-banner__confirmation"
-  //     );
-  //     expect(confirmBanner.style.display).toEqual("block");
-
-  //     confirmBanner.querySelector(".pay-cookie-banner__hide-button").click();
-  //     expect(confirmBanner.style.display).toEqual("none");
-  //   });
-  // });
 });


### PR DESCRIPTION
* Update banner.html with css styling
    * functionality and tests for Cookie banner > confirmation message
     * Add test to check that the confirmation message is shown when you you click Yes or No
       on the cookie banner.
     * Also test that the hide link in the confirmation message hides the banner.