### PR TITLE
ZD4487202 Fix styling for MHRA custom branding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "main": "lib/index.js",
   "scripts": {

--- a/sass/custom/mhra.scss
+++ b/sass/custom/mhra.scss
@@ -40,11 +40,26 @@ $logo-image-height: 2em;
     border-bottom-color: $custom-banner-border-colour;
   }
 
-  @include govuk-media-query($from: tablet) {
+  @include govuk-media-query($from: 48em) {
     .govuk-header__content {
       width: 66%;
       vertical-align: bottom;
       margin-bottom: 7px;
+    }
+    .govuk-header__link--service-name {
+      padding-top: 15px;
+      float: right;
+    }
+  }
+
+  @include govuk-media-query($until: 48em) {
+    .govuk-header__content {
+      width: 99%;
+      text-align: center;
+    }
+    .govuk-header__link--service-name {
+      padding-top: 5px;
+      float: none;
     }
   }
 


### PR DESCRIPTION
## WHAT
- Fixes styling for service name
- Bump version to 3.0.9

Previously logo looks like
<img width="785" alt="Screenshot 2021-03-15 at 16 26 42" src="https://user-images.githubusercontent.com/40598480/111186780-421c8800-85ab-11eb-925e-997b7a29260a.png">

and now

<img width="835" alt="Screenshot 2021-03-15 at 16 25 14" src="https://user-images.githubusercontent.com/40598480/111186700-2dd88b00-85ab-11eb-853b-8ac426dc6e89.png">



