### PR TITLE
PP-8015 Cookie banner - replace "aria-describedby" with "aria-label=cookie banner"

### DIFF
--- a/src/analytics/cookies/banner.html
+++ b/src/analytics/cookies/banner.html
@@ -128,7 +128,7 @@
 		}
 	}
 </style>
-<div id="pay-cookie-banner" class="pay-cookie-banner govuk-width-container" data-module="pay-cookie-banner" role="region" aria-describedby="pay-cookie-banner__heading">
+<div id="pay-cookie-banner" class="pay-cookie-banner govuk-width-container" data-module="pay-cookie-banner" role="region" aria-label="cookie banner">
 	<div class="pay-cookie-banner__wrapper">
 		<h2 class="pay-cookie-banner__heading govuk-heading-m" id="pay-cookie-banner__heading">
 			Can we store analytics cookies on your device?


### PR DESCRIPTION
- This will make it easier for screen readers to navigate through the cookie banner.