### PR TITLE
PP-8497 Add human-readable webhook subscription names

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -10,5 +10,16 @@ module.exports = {
     MIN_KEY_LENGTH: 1,
     MAX_KEY_LENGTH: 30,
     MAX_VALUE_LENGTH: 100
+  },
+
+
+  webhooks: {
+    humanReadableSubscriptions: {
+      /*
+      Keys match those defined here:
+      https://github.com/alphagov/pay-webhooks/blob/main/src/main/java/uk/gov/pay/webhooks/eventtype/EventTypeName.java
+      */
+      CARD_PAYMENT_CAPTURED: 'Payment captured'
+    }
   }
 }


### PR DESCRIPTION
With webhooks, one can subscribe to events, which have names like `CARD_PAYMENT_CAPTURED`. These are not human-friendly, so we want to maintain a mapping from the harsh, robotic, computer names to soft, friendly, human names like ‘Card payment captured’, which we can then use in selfservice and toolbox etc and other places where they will be seen by humans.