### PR TITLE
ZD-4769105: Change alignment of L&G NHS Logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "main": "lib/index.js",
   "scripts": {

--- a/sass/custom/lewisham-and-greenwich-nhs-trust.scss
+++ b/sass/custom/lewisham-and-greenwich-nhs-trust.scss
@@ -8,12 +8,12 @@ $govuk-font-family: -apple-system,BlinkMacSystemFont,helvetica neue,helvetica,ub
 $custom-banner-colour: #005EB8;
 $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
-$logo-image-height: 2em;
+$logo-image-width: 215px;
 
 .custom-branding {
-  @if $logo-image-height != null {
+  @if $logo-image-width != null {
     .custom-branding-image {
-      max-height: $logo-image-height;
+      width: $logo-image-width;
 
       @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
         width: 100%;
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     border-bottom-color: $custom-banner-border-colour;
   }
 
+  .govuk-header__logo {
+    float: right;
+  }
+
   @include govuk-media-query($from: 48em) {
     .govuk-header__content {
       width: 66%;
@@ -52,7 +56,7 @@ $logo-image-height: 2em;
     }
     .govuk-header__link--service-name {
       padding-top: 15px;
-      float: right;
+      float: left;
     }
   }
 


### PR DESCRIPTION
## What?
This is an amendment to the Lewisham & Greenwich NHS Trust custom branding CSS to swap around the Logo and Service Title elements - the Logo asset in question is designed to be right-aligned and the Sass changes included should rectify this.

The `float:right;` should be applied to all display sizes as this will also put it in the right place on mobile.

## Related Items
https://github.com/alphagov/pay-js-commons/pull/776