### PR TITLE
[ZD-4775772] Adding requested padding to PCC Logo

### DIFF
--- a/sass/custom/portsmouth.scss
+++ b/sass/custom/portsmouth.scss
@@ -25,6 +25,17 @@ $logo-image-height: 2em;
     background-color: $custom-banner-colour;
   }
 
+  .govuk-header__logo {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    .govuk-header__logo {
+      padding-left: 5px;
+    }
+  }
+
   .govuk-header__link{
     &:link,
     &:visited {
@@ -44,6 +55,7 @@ $logo-image-height: 2em;
     .govuk-header__content {
       width: 66%;
       vertical-align: bottom;
+      padding-top: 15px;
       margin-bottom: 7px;
     }
   }


### PR DESCRIPTION
## What?
It has been requested if there could be approximately 20px worth of padding surrounding the Portsmouth CC logo, in order to more closely conform to PCC's branding guidelines.

## Preview
![image](https://user-images.githubusercontent.com/68009085/142619255-c9052d18-ffb9-420d-9aa1-1d8f684f8220.png)
