### PR TITLE
BAU Strip all special characters for generating URLs

### DIFF
--- a/src/nunjucks-filters/slugify.js
+++ b/src/nunjucks-filters/slugify.js
@@ -22,7 +22,7 @@ module.exports = string => {
   return slugify(
     string,
     {
-      remove: /[$*_+~.()'"!:@?%=£]/g,
+      remove: /[^A-Za-z0-9\s-]/g,
       lower: true
     }
   )

--- a/src/nunjucks-filters/slugify.test.js
+++ b/src/nunjucks-filters/slugify.test.js
@@ -5,7 +5,7 @@ const slugify = require('./slugify')
 
 describe('When a string is passed through the Nunjucks slugify filter', () => {
   it('it should make it url friendly', () => {
-    expect(slugify('Someones’s string')).to.equal('someoness-string')
+    expect(slugify('Someönés*_+~.()\'"!:@?=,;{}/[]s string with-hyphen')).to.equal('someoness-string-with-hyphen')
   })
 
   it('should replace all Welsh accented vowels with unaccented characters', () => {


### PR DESCRIPTION
    A service was running into issues as their service name contains commas,
    causing the payment link that was created to have a strange looking URL
    that was then blocked by NAXSI rules.

    Strip all special characters from generated URLs.

    Removing the characters runs after slugify has run, so some special
    characters will be replaced by words, such as $ -> dollar