### PR TITLE
3.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.8.0",
+  "version": "3.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-pay/pay-js-commons",
-      "version": "3.8.0",
+      "version": "3.8.3",
       "license": "MIT",
       "dependencies": {
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.8.0",
+  "version": "3.8.3",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "engines": {
     "node": "^16.14.0"


### PR DESCRIPTION
Bump version number to 3.8.3

This was missed for 3.8.2, and there is no 3.8.1 release, but I don't know where 3.8.2 was so I'm choosing to bypass trying to pick the correct commit for 3.8.2 and just knowing this PR brings us back into correct version alignment