### PR TITLE
ZD-5142738: Add new NIBSC sass for displaying SVG logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-pay/pay-js-commons",
-      "version": "3.8.4",
+      "version": "3.8.5",
       "license": "MIT",
       "dependencies": {
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "engines": {
     "node": "^16.14.0"

--- a/sass/custom/nibsc-standards-2023-01.scss
+++ b/sass/custom/nibsc-standards-2023-01.scss
@@ -1,0 +1,56 @@
+$govuk-font-family: -apple-system,BlinkMacSystemFont,helvetica neue,helvetica,ubuntu,roboto,noto,segoe ui,arial,sans-serif; // Override font as so not to use New Transport
+@import "application";
+
+// CUSTOM BRANDING
+// Use the variables below to control the style
+// Make sure banner colours meet minimum colour contrast levels
+
+$custom-banner-colour: #008489;
+$custom-banner-border-colour: #ffffff;
+$custom-text-colour: #ffffff;
+$logo-image-height: 2em;
+
+.custom-branding {
+  @if $logo-image-height != null {
+    .custom-branding-image {
+      height: $logo-image-height;
+      width: 100%;
+
+      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+        width: 100%;
+      }
+    }
+  }
+
+  .govuk-header {
+    background-color: $custom-banner-colour;
+  }
+
+  .govuk-header__link {
+    &:link,
+    &:visited {
+      color: $custom-text-colour;
+    }
+  }
+
+  .govuk-header__link--service-name {
+    display: none;
+  }
+
+  .govuk-header__container {
+    border-bottom-color: $custom-banner-border-colour;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    .govuk-header__content {
+      width: 66%;
+      vertical-align: bottom;
+      margin-bottom: 7px;
+    }
+  }
+
+  .govuk-button {
+    padding: 7px 15px 6px;
+    padding: .368421053em .842105263em .315789474em;
+  }
+}


### PR DESCRIPTION
Adds a width to ensure the SVG is displayed.

Version 3.8.5 has been published to NPM.