### PR TITLE
Revert "Bump jsdom from 20.0.3 to 21.1.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "jest": "^29.4.3",
         "jest-environment-jsdom": "^29.4.3",
         "js-cookie": "^3.0.0",
-        "jsdom": "^21.1.0",
+        "jsdom": "^20.0.1",
         "jsdom-global": "^3.0.2",
         "karma": "^6.0.0",
         "karma-browserify": "^8.0.0",
@@ -10968,9 +10968,9 @@
       "dev": true
     },
     "node_modules/jsdom": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.0.tgz",
-      "integrity": "sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "dependencies": {
         "abab": "^2.0.6",
@@ -26353,9 +26353,9 @@
       "dev": true
     },
     "jsdom": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.0.tgz",
-      "integrity": "sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "requires": {
         "abab": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "jest": "^29.4.3",
     "jest-environment-jsdom": "^29.4.3",
     "js-cookie": "^3.0.0",
-    "jsdom": "^21.1.0",
+    "jsdom": "^20.0.1",
     "jsdom-global": "^3.0.2",
     "karma": "^6.0.0",
     "karma-browserify": "^8.0.0",


### PR DESCRIPTION
Reverts alphagov/pay-js-commons#1093

(the post-merge tests failed, possibly because of Dependabot not rebasing properly)