### PR TITLE
Bump version to 3.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-pay/pay-js-commons",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-pay/pay-js-commons",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "engines": {
     "node": "^16.20.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "engines": {
     "node": "^16.20.1"


### PR DESCRIPTION
## WHAT
- Bumps version to 3.11.1 post branding changes https://github.com/alphagov/pay-js-commons/pull/1207
- Had to do a patch release as the minor version release did not include intended changes.