### PR TITLE
BAU update karma configuration

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,13 +1,15 @@
 'use strict'
 
 module.exports = karma => karma.set({
+  basePath: './src',
   frameworks: [
     'browserify',
     'source-map-support',
     'mocha'
   ],
   files: [
-    'src/!(analytics)**/*.js'
+    'index.js',
+    '!(analytics)**/**/*.js'
   ],
   plugins: [
     'karma-mocha',
@@ -21,7 +23,7 @@ module.exports = karma => karma.set({
     transform: [['babelify']]
   },
   preprocessors: {
-    'src/**/*.js': ['browserify']
+    '**/*.js': [ 'browserify' ]
   },
   reporters: ['mocha'],
   browsers: ['ChromiumNoSandbox'],

--- a/src/browsered/field-validation/field-validation.test.js
+++ b/src/browsered/field-validation/field-validation.test.js
@@ -51,10 +51,10 @@ describe('Field validation', () => {
     it('It should show an error summary', () => {
       expect(document.querySelector('#error-summary')).to.exist // eslint-disable-line no-unused-expressions
     })
-    it(`The error summary should link to the errored input ‘${fixtures.inputId}’`, () => {
+    it(`The error summary should link to the errored input '${fixtures.inputId}'`, () => {
       expect(document.querySelector(`a[href="#${fixtures.inputId}"]`)).to.exist // eslint-disable-line no-unused-expressions
     })
-    it(`The error summary should link text should be ‘${fixtures.label}’`, () => {
+    it(`The error summary should link text should be '${fixtures.label}`, () => {
       expect(document.querySelector(`a[href="#${fixtures.inputId}"]`).innerHTML).to.equal(`${fixtures.label}`)
     })
   })


### PR DESCRIPTION
### WHAT

- amend karma configuration to:
  - prevent excluding certain tests erroneously
  - fix bug where `GOVUKPAY` was not being assigned to the global `window` object during headless test runs