### PR TITLE
ZD-5469011: Allow apostrophe's in prefilled payment link references

### DIFF
--- a/src/browsered/field-validation/field-validation.test.js
+++ b/src/browsered/field-validation/field-validation.test.js
@@ -452,12 +452,9 @@ describe('Field validation', () => {
     })
 
     describe('where value is NAXSI safe', () => {
-      before('Act', () => {
+      it('should submit the form', () => {
         document.querySelector(`#${fixtures.inputId}`).value = '123'
         document.querySelector('button').click()
-      })
-
-      it('should submit the form', () => {
         expect(document.querySelector('#fixture').submit.called).to.equal(true)
       })
     })

--- a/src/browsered/field-validation/field-validation.test.js
+++ b/src/browsered/field-validation/field-validation.test.js
@@ -441,7 +441,7 @@ describe('Field validation', () => {
 
     describe('where value contains NAXSI flaggable characters', () => {
       before('Act', () => {
-        document.querySelector(`#${fixtures.inputId}`).value = '<?php echo \'bad things\'; ?>'
+        document.querySelector(`#${fixtures.inputId}`).value = '<?php echo "bad things"; ?>'
         document.querySelector('button').click()
       })
 

--- a/src/browsered/field-validation/field-validation.test.js
+++ b/src/browsered/field-validation/field-validation.test.js
@@ -441,7 +441,7 @@ describe('Field validation', () => {
 
     describe('where value contains NAXSI flaggable characters', () => {
       before('Act', () => {
-        document.querySelector(`#${fixtures.inputId}`).value = '<?php echo \'bad things\'; ?>'
+        document.querySelector(`#${fixtures.inputId}`).value = 'O\'Connell '
         document.querySelector('button').click()
       })
 

--- a/src/browsered/field-validation/field-validation.test.js
+++ b/src/browsered/field-validation/field-validation.test.js
@@ -441,7 +441,7 @@ describe('Field validation', () => {
 
     describe('where value contains NAXSI flaggable characters', () => {
       before('Act', () => {
-        document.querySelector(`#${fixtures.inputId}`).value = 'O’Connell'
+        document.querySelector(`#${fixtures.inputId}`).value = '<?php echo \'bad things\'; ?>'
         document.querySelector('button').click()
       })
 
@@ -454,6 +454,11 @@ describe('Field validation', () => {
     describe('where value is NAXSI safe', () => {
       it('should submit the form', () => {
         document.querySelector(`#${fixtures.inputId}`).value = '123'
+        document.querySelector('button').click()
+        expect(document.querySelector('#fixture').submit.called).to.equal(true)
+      })
+      it('apostrophes should be ok', () => {
+        document.querySelector(`#${fixtures.inputId}`).value = 'O’Connell'
         document.querySelector('button').click()
         expect(document.querySelector('#fixture').submit.called).to.equal(true)
       })

--- a/src/browsered/field-validation/field-validation.test.js
+++ b/src/browsered/field-validation/field-validation.test.js
@@ -441,7 +441,7 @@ describe('Field validation', () => {
 
     describe('where value contains NAXSI flaggable characters', () => {
       before('Act', () => {
-        document.querySelector(`#${fixtures.inputId}`).value = 'O\'Connell '
+        document.querySelector(`#${fixtures.inputId}`).value = 'O’Connell'
         document.querySelector('button').click()
       })
 

--- a/src/utils/field-validation-checks.js
+++ b/src/utils/field-validation-checks.js
@@ -73,7 +73,7 @@ exports.isFieldGreaterThanMaxLengthChars = (value, maxLength) => {
 exports.isPasswordLessThanTenChars = value => !value || value.length < 10 ? validationErrors.isPasswordLessThanTenChars : false
 
 exports.isNaxsiSafe = function (value) {
-  if (/[<>;:`()"'=|,~[\]]+/g.test(value)) {
+  if (/[<>;:`()"=|,~[\]]+/g.test(value)) {
     return validationErrors.invalidCharacters
   }
   return false


### PR DESCRIPTION
Given we've allowed apostrophe's ([NAXSI rule 1013](https://github.com/nbs-system/naxsi/blob/master/naxsi_config/naxsi_core.rules#L37)) on [creating payment links](https://github.com/alphagov/pay-infra/blob/master/provisioning/terraform/modules/pay_microservices_v2/products-ui/files/products-ui.naxsi) we should relax the rule here in pay-js-commons.