### PR TITLE
PP-11040 Custom logos - remove hover state

### DIFF
--- a/sass/custom/adur-and-worthing-council.scss
+++ b/sass/custom/adur-and-worthing-council.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/barking-havering-redbridge-nhs-trust.scss
+++ b/sass/custom/barking-havering-redbridge-nhs-trust.scss
@@ -32,6 +32,14 @@ $logo-image-width: 320px;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/bracknell-forest.scss
+++ b/sass/custom/bracknell-forest.scss
@@ -32,6 +32,14 @@ $logo-image-height: 3em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/british-pharmacopoeia.scss
+++ b/sass/custom/british-pharmacopoeia.scss
@@ -33,6 +33,14 @@ $logo-image-height: 1.5em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
     float: none;

--- a/sass/custom/caa.scss
+++ b/sass/custom/caa.scss
@@ -32,10 +32,11 @@ $logo-image-height: 3.5em;
     }
   }
 
-  .govuk-header__link--homepage{
-    &:hover {
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
       margin-bottom: 0;
-      border-bottom: inherit;
     }
   }
 

--- a/sass/custom/cadw-welsh-government-2023.scss
+++ b/sass/custom/cadw-welsh-government-2023.scss
@@ -31,6 +31,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/cadw-welsh-government.scss
+++ b/sass/custom/cadw-welsh-government.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/canterbury-city-council.scss
+++ b/sass/custom/canterbury-city-council.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/croydon-council.scss
+++ b/sass/custom/croydon-council.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/custom.scss
+++ b/sass/custom/custom.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/dacorum.scss
+++ b/sass/custom/dacorum.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/disclosure-scotland.scss
+++ b/sass/custom/disclosure-scotland.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/ea-defra.scss
+++ b/sass/custom/ea-defra.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/edinburgh-council-pest-control.scss
+++ b/sass/custom/edinburgh-council-pest-control.scss
@@ -34,6 +34,14 @@ $logo-image-width-from-tablet: 270px;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/food-standards-agency.scss
+++ b/sass/custom/food-standards-agency.scss
@@ -32,6 +32,14 @@ $logo-image-height: 1.5em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     float: right;
     padding-top: 8px;

--- a/sass/custom/gambling-commission.scss
+++ b/sass/custom/gambling-commission.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
@@ -32,6 +32,14 @@ $logo-image-height: 1.5em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     float: right;
     padding-top: 8px;

--- a/sass/custom/gwent-police.scss
+++ b/sass/custom/gwent-police.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/hiw.scss
+++ b/sass/custom/hiw.scss
@@ -35,6 +35,14 @@ $logo-image-width-from-tablet: 350px;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/kcc.scss
+++ b/sass/custom/kcc.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2.5rem;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/kingston.scss
+++ b/sass/custom/kingston.scss
@@ -32,6 +32,14 @@ $logo-image-height: 4em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/lbbd.scss
+++ b/sass/custom/lbbd.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/london-fire-brigade.scss
+++ b/sass/custom/london-fire-brigade.scss
@@ -35,6 +35,14 @@ $logo-image-height: 1.5em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
     float: none;

--- a/sass/custom/merseyside-police.scss
+++ b/sass/custom/merseyside-police.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/ministry-of-defence-dbs-fps.scss
+++ b/sass/custom/ministry-of-defence-dbs-fps.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/national-museums-ni.scss
+++ b/sass/custom/national-museums-ni.scss
@@ -33,6 +33,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     display: none;
   }

--- a/sass/custom/natural-resources-wales.scss
+++ b/sass/custom/natural-resources-wales.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     float: right;
     padding-top: 15px;

--- a/sass/custom/neath-port-talbot-county-borough-council-2023.scss
+++ b/sass/custom/neath-port-talbot-county-borough-council-2023.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/neath_port_talbet_council.scss
+++ b/sass/custom/neath_port_talbet_council.scss
@@ -33,6 +33,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     display: none;
   }

--- a/sass/custom/nhsbsa.scss
+++ b/sass/custom/nhsbsa.scss
@@ -32,6 +32,14 @@ $logo-image-width: 300px;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/nottingham-university-hospitals-trust.scss
+++ b/sass/custom/nottingham-university-hospitals-trust.scss
@@ -32,6 +32,14 @@ $logo-image-height: 3em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/oswestry-town-council.scss
+++ b/sass/custom/oswestry-town-council.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/planning-and-building-services-edinburgh.scss
+++ b/sass/custom/planning-and-building-services-edinburgh.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/portsmouth.scss
+++ b/sass/custom/portsmouth.scss
@@ -43,6 +43,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/runnymede-borough-council.scss
+++ b/sass/custom/runnymede-borough-council.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/rushmoor.scss
+++ b/sass/custom/rushmoor.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/scottish-government-planning.scss
+++ b/sass/custom/scottish-government-planning.scss
@@ -33,6 +33,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/social-security-scotland.scss
+++ b/sass/custom/social-security-scotland.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2.5em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/someret-west-and-taunton.scss
+++ b/sass/custom/someret-west-and-taunton.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/south-wales-police.scss
+++ b/sass/custom/south-wales-police.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/stratford-upon-avon.scss
+++ b/sass/custom/stratford-upon-avon.scss
@@ -32,6 +32,14 @@ $logo-image-height: 3em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/sutton.scss
+++ b/sass/custom/sutton.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/the-coal-authority.scss
+++ b/sass/custom/the-coal-authority.scss
@@ -32,6 +32,14 @@ $logo-image-height: 1.5em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     float: right;
     padding-top: 8px;

--- a/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
+++ b/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
@@ -32,6 +32,14 @@ $logo-image-height: 4em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/wealden.scss
+++ b/sass/custom/wealden.scss
@@ -32,10 +32,11 @@ $logo-image-height: 3.5em;
     }
   }
 
-  .govuk-header__link--homepage{
-    &:hover {
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
       margin-bottom: 0;
-      border-bottom: inherit;
     }
   }
 

--- a/sass/custom/west-berkshire-council.scss
+++ b/sass/custom/west-berkshire-council.scss
@@ -32,6 +32,14 @@ $logo-image-height: 2em;
     }
   }
 
+  .govuk-header__link--homepage {
+    &:hover,
+    &:active {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
   .govuk-header__link--service-name {
     color: $custom-text-colour;
   }


### PR DESCRIPTION
- Bug on the custom logo, shows an hover state even though it is not a link.
- Remove the hover styling in the custom branding SASS files.
- Had to update all custom SASS files.
- Also custom to the custom SASS template file - custom.scss
  - So future custom branding requests will automatically pick up the change.