### PR TITLE
PP-11683 Replace 'request' library with 'axios'

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,10 +21,17 @@ module.exports = karma => karma.set({
   ],
   browserify: {
     debug: true, // Gets us source-maps, which in turn gets us human-readable error stacks in tests
-    transform: [['babelify']]
+    transform: [[
+      'babelify',
+      {
+        global: true,
+        presets: ['@babel/preset-env']
+      }
+    ]
+    ]
   },
   preprocessors: {
-    '**/*.js': [ 'browserify' ]
+    '**/*.js': ['browserify']
   },
   reporters: ['mocha'],
   browsers: ['ChromiumNoSandbox'],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,8 @@ module.exports = karma => karma.set({
   ],
   files: [
     'index.js',
-    '!(analytics)**/**/*.js'
+    '!(analytics)**/**/*.js',
+    'utils/axios-base-client.test.js'
   ],
   plugins: [
     'karma-mocha',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "4.0.13",
       "license": "MIT",
       "dependencies": {
+        "axios": "^1.6.5",
+        "chai-as-promised": "^7.1.1",
         "lodash": "4.17.21",
         "moment-timezone": "0.5.43",
+        "nock": "^13.5.0",
         "rfc822-validate": "1.0.0",
         "slugify": "1.6.6",
         "winston": "3.9.0"
@@ -3849,7 +3852,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -3877,8 +3879,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -3906,6 +3907,29 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
+    },
+    "node_modules/axios": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.6.0",
@@ -4750,7 +4774,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
       "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
-      "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -4762,6 +4785,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chalk": {
@@ -4791,7 +4825,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -5046,7 +5079,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5512,7 +5544,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
       "integrity": "sha512-gT18+YW4CcW/DBNTwAmqTtkJh7f9qqScu2qFVlx7kCoeY9tlBu9cUcr7+I+Z/noG8INehS3xQgLpTtd/QUTn4w==",
-      "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -5573,7 +5604,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7840,7 +7870,6 @@
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
       "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7998,7 +8027,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -11622,8 +11650,7 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -12484,7 +12511,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
       "integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
-      "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
@@ -12905,7 +12931,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12914,7 +12939,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -13491,6 +13515,35 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nock": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.0.tgz",
+      "integrity": "sha512-9hc1eCS2HtOz+sE9W7JQw/tXJktg0zoPSu48s/pYe73e25JW9ywiowbqnUSd7iZPeVawLcVpPZeZS312fwSY+g==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/nock/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -14017,7 +14070,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -14391,6 +14443,14 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/proto-props": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/proto-props/-/proto-props-2.0.0.tgz",
@@ -14399,6 +14459,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -16503,7 +16568,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -21191,8 +21255,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -21214,8 +21277,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -21234,6 +21296,28 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "requires": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "babel-jest": {
       "version": "29.6.0",
@@ -21913,7 +21997,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
       "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
-      "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -21922,6 +22005,14 @@
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chalk": {
@@ -21944,8 +22035,7 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "chokidar": {
       "version": "3.5.2",
@@ -22153,7 +22243,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -22557,7 +22646,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
       "integrity": "sha512-gT18+YW4CcW/DBNTwAmqTtkJh7f9qqScu2qFVlx7kCoeY9tlBu9cUcr7+I+Z/noG8INehS3xQgLpTtd/QUTn4w==",
-      "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -22599,8 +22687,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "2.0.0",
@@ -24309,8 +24396,7 @@
     "follow-redirects": {
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
-      "dev": true
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -24421,8 +24507,7 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "get-intrinsic": {
       "version": "1.1.3",
@@ -27074,8 +27159,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.3",
@@ -27721,7 +27805,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
       "integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
-      "dev": true,
       "requires": {
         "get-func-name": "^2.0.0"
       }
@@ -28026,14 +28109,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -28474,6 +28555,26 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "nock": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.0.tgz",
+      "integrity": "sha512-9hc1eCS2HtOz+sE9W7JQw/tXJktg0zoPSu48s/pYe73e25JW9ywiowbqnUSd7iZPeVawLcVpPZeZS312fwSY+g==",
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -28875,8 +28976,7 @@
     "pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
     },
     "pbkdf2": {
       "version": "3.1.1",
@@ -29138,11 +29238,21 @@
         }
       }
     },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag=="
+    },
     "proto-props": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/proto-props/-/proto-props-2.0.0.tgz",
       "integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
       "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.8.0",
@@ -30761,8 +30871,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "npm run transpile && npm run browserify-analytics",
     "test": "npm run jest-tests npm && npm run karma-tests",
     "karma-tests": "karma start",
-    "jest-tests": "jest src/analytics",
+    "jest-tests": "jest src/analytics src/utils/axios-base-client.test.js",
     "lint": "standard --fix"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -142,8 +142,11 @@
     "lib": "lib"
   },
   "dependencies": {
+    "axios": "^1.6.5",
+    "chai-as-promised": "^7.1.1",
     "lodash": "4.17.21",
     "moment-timezone": "0.5.43",
+    "nock": "^13.5.0",
     "rfc822-validate": "1.0.0",
     "slugify": "1.6.6",
     "winston": "3.9.0"

--- a/src/utils/axios-base-client.js
+++ b/src/utils/axios-base-client.js
@@ -27,7 +27,7 @@ class Client {
       }),
       headers: {
         'Content-Type': 'application/json',
-        'Accept': 'application/json'
+        Accept: 'application/json'
       }
     })
 

--- a/src/utils/axios-base-client.js
+++ b/src/utils/axios-base-client.js
@@ -1,0 +1,146 @@
+'use strict'
+
+const http = require('http')
+const https = require('https')
+const axios = require('axios')
+const { RESTClientError } = require('./errors')
+
+class Client {
+  constructor (app) {
+    this._app = app
+  }
+
+  /**
+   * Configure the client. Should only be called once.
+   */
+  configure (baseURL, options) {
+    this._axios = axios.create({
+      baseURL,
+      timeout: 60 * 1000,
+      maxContentLength: 50 * 1000 * 1000,
+      httpAgent: new http.Agent({
+        keepAlive: true
+      }),
+      httpsAgent: new https.Agent({
+        keepAlive: true,
+        rejectUnauthorized: process.env.NODE_ENV === 'production'
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+    })
+
+    this._axios.interceptors.request.use(config => {
+      const requestContext = {
+        service: this._app,
+        method: config.method,
+        url: config.url,
+        description: config.description,
+        additionalLoggingFields: config.additionalLoggingFields,
+        ...config.retryCount && { retryCount: config.retryCount }
+      }
+      if (options.onRequestStart) {
+        options.onRequestStart(requestContext)
+      }
+
+      const headers = options.transformRequestAddHeaders ? options.transformRequestAddHeaders() : {}
+      Object.entries(headers)
+        .forEach(([headerKey, headerValue]) => {
+          config.headers[headerKey] = headerValue
+        })
+
+      return {
+        ...config,
+        metadata: { start: Date.now() }
+      }
+    })
+
+    this._axios.interceptors.response.use((response) => {
+      const responseContext = {
+        service: this._app,
+        responseTime: Date.now() - (response.config).metadata.start,
+        method: response.config.method,
+        params: response.config.params,
+        status: response.status,
+        url: response.config.url,
+        description: response.config.description,
+        additionalLoggingFields: response.config.additionalLoggingFields
+      }
+      if (options.onSuccessResponse) {
+        options.onSuccessResponse(responseContext)
+      }
+      return response
+    }, async (error) => {
+      const config = error.config || {}
+      let errors = error.response.data && (error.response.data.message || error.response.data.errors)
+      if (errors && Array.isArray(errors)) {
+        errors = errors.join(', ')
+      }
+      const errorContext = {
+        service: this._app,
+        responseTime: Date.now() - (config.metadata && config.metadata.start),
+        method: config.method,
+        params: config.params,
+        status: error.response && error.response.status,
+        url: config.url,
+        code: (error.response && error.response.status) || error.code,
+        errorIdentifier: error.response && error.response.data && error.response.data.error_identifier,
+        reason: error.response && error.response.data && error.response.data.reason,
+        message: errors || error.response.data || 'Unknown error',
+        description: config.description,
+        additionalLoggingFields: config.additionalLoggingFields
+      }
+
+      // TODO: could use axios-retry to achieve this if desired
+      // Retry ECONNRESET errors for GET requests 3 times in total
+      if (config.method === 'get' && error.code === 'ECONNRESET') {
+        const retryCount = config.retryCount || 0
+        if (retryCount < 2) {
+          config.retryCount = retryCount + 1
+          if (options.onFailureResponse) {
+            errorContext.retry = true
+            options.onFailureResponse(errorContext)
+          }
+          await new Promise(resolve => setTimeout(resolve, 500))
+          return this._axios(config)
+        }
+      }
+      if (options.onFailureResponse) {
+        options.onFailureResponse(errorContext)
+      }
+      throw new RESTClientError(errorContext.message, errorContext.service, errorContext.status, errorContext.errorIdentifier, errorContext.reason)
+    })
+  }
+
+  _getConfigWithDescription (config = {}, description) {
+    return {
+      ...config,
+      description
+    }
+  }
+
+  get (url, description, config) {
+    return this._axios.get(url, this._getConfigWithDescription(config, description))
+  }
+
+  post (url, payload, description, config) {
+    return this._axios.post(url, payload, this._getConfigWithDescription(config, description))
+  }
+
+  put (url, payload, description, config) {
+    return this._axios.put(url, payload, this._getConfigWithDescription(config, description))
+  }
+
+  patch (url, payload, description, config) {
+    return this._axios.patch(url, payload, this._getConfigWithDescription(config, description))
+  }
+
+  delete (url, description, config) {
+    return this._axios.delete(url, this._getConfigWithDescription(config, description))
+  }
+}
+
+module.exports = {
+  Client
+}

--- a/src/utils/axios-base-client.test.js
+++ b/src/utils/axios-base-client.test.js
@@ -178,7 +178,6 @@ describe('Axios base client', () => {
         expect(requestFailureSpy.mock.calls[0][0].retryCount).toBeUndefined()
         expect(nock.isDone()).toEqual(true)
       }
-
     })
 
     it('should not retry for an error other than ECONNRESET', async () => {

--- a/src/utils/axios-base-client.test.js
+++ b/src/utils/axios-base-client.test.js
@@ -1,0 +1,200 @@
+'use strict'
+
+const nock = require('nock')
+const sinon = require('sinon')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const { Client } = require('./axios-base-client')
+
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const baseUrl = 'http://localhost:8000'
+const app = 'an-app'
+
+describe('Axios base client', () => {
+  const requestStartSpy = sinon.spy()
+  const requestSuccessSpy = sinon.spy()
+  const requestFailureSpy = sinon.spy()
+  const client = new Client(app)
+  client.configure(baseUrl, {
+    onRequestStart: requestStartSpy,
+    onSuccessResponse: requestSuccessSpy,
+    onFailureResponse: requestFailureSpy
+  })
+
+  beforeEach(() => {
+    requestStartSpy.resetHistory()
+    requestFailureSpy.resetHistory()
+    requestSuccessSpy.resetHistory()
+  })
+
+  describe('Response and hooks', () => {
+    it('should return response and call success hook on 200 response', () => {
+      const body = { foo: 'bar' }
+      nock(baseUrl)
+        .get('/')
+        .reply(200, body)
+
+      return expect(client.get('/', 'doing something', {
+        additionalLoggingFields: { foo: 'bar' }
+      })).to.be.fulfilled.then((response) => {
+        expect(response.data).to.deep.equal(body)
+        sinon.assert.calledWith(requestStartSpy, {
+          service: app,
+          method: 'get',
+          url: '/',
+          description: 'doing something',
+          additionalLoggingFields: { foo: 'bar' }
+        })
+        sinon.assert.calledWith(requestSuccessSpy, {
+          service: app,
+          responseTime: sinon.match.number,
+          method: 'get',
+          params: undefined,
+          status: 200,
+          url: '/',
+          description: 'doing something',
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      })
+    })
+
+    it('should throw error and call failure hook on 400 response', () => {
+      const body = {
+        error_identifier: 'AN-ERROR',
+        message: 'a-message',
+        reason: 'something'
+      }
+      nock(baseUrl)
+        .get('/')
+        .reply(400, body)
+
+      return expect(client.get('/', 'doing something', {
+        additionalLoggingFields: { foo: 'bar' }
+      })).to.be.rejected.then((error) => {
+        expect(error.message).to.equal('a-message')
+        expect(error.errorCode).to.equal(400)
+        expect(error.errorIdentifier).to.equal('AN-ERROR')
+        expect(error.service).to.equal(app)
+
+        sinon.assert.calledWith(requestFailureSpy, {
+          service: app,
+          responseTime: sinon.match.number,
+          method: 'get',
+          params: undefined,
+          status: 400,
+          url: '/',
+          code: 400,
+          errorIdentifier: body.error_identifier,
+          reason: 'something',
+          message: body.message,
+          description: 'doing something',
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      })
+    })
+
+    it('should throw error and call failure hook on 500 response', () => {
+      const body = {
+        error_identifier: 'AN-ERROR',
+        message: 'a-message',
+        reason: 'something'
+      }
+      nock(baseUrl)
+        .get('/')
+        .reply(500, body)
+
+      return expect(client.get('/', 'doing something', {
+        additionalLoggingFields: { foo: 'bar' }
+      })).to.be.rejected.then((error) => {
+        expect(error.message).to.equal('a-message')
+        expect(error.errorCode).to.equal(500)
+        expect(error.errorIdentifier).to.equal('AN-ERROR')
+        expect(error.service).to.equal(app)
+
+        sinon.assert.calledWith(requestFailureSpy, {
+          service: app,
+          responseTime: sinon.match.number,
+          method: 'get',
+          params: undefined,
+          status: 500,
+          url: '/',
+          code: 500,
+          errorIdentifier: body.error_identifier,
+          reason: 'something',
+          message: body.message,
+          description: 'doing something',
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      })
+    })
+  })
+
+  describe('Retries', () => {
+    it('should retry GET request 3 times when ECONNRESET error thrown', () => {
+      nock(baseUrl)
+        .get('/')
+        .times(3)
+        .replyWithError({
+          code: 'ECONNRESET',
+          response: { status: 500 }
+        })
+
+      return expect(client.get('/', 'foo')).to.be.rejected.then(error => {
+        expect(error.errorCode).to.equal(500)
+        sinon.assert.calledThrice(requestStartSpy)
+        requestStartSpy.getCall(0).calledWithMatch({
+          method: 'get',
+          url: '/'
+        })
+        requestStartSpy.getCall(1).calledWithMatch({
+          method: 'get',
+          url: '/',
+          retryCount: 2
+        })
+        requestStartSpy.getCall(2).calledWithMatch({
+          method: 'get',
+          url: '/',
+          retryCount: 3
+        })
+        sinon.assert.calledThrice(requestFailureSpy)
+        sinon.assert.calledWithMatch(requestFailureSpy, { retry: true })
+        expect(nock.isDone()).to.eq(true)
+      })
+    })
+
+    it('should not retry POST requests when ECONNRESET error returned', () => {
+      nock(baseUrl)
+        .post('/')
+        .replyWithError({
+          code: 'ECONNRESET',
+          response: { status: 500 }
+        })
+
+      return expect(client.post('/')).to.be.rejected.then(error => {
+        expect(error.errorCode).to.equal(500)
+        sinon.assert.calledOnce(requestStartSpy)
+        sinon.assert.calledOnce(requestFailureSpy)
+        expect(requestFailureSpy.getCall(0).args.retry === undefined)
+        expect(nock.isDone()).to.eq(true)
+      })
+    })
+
+    it('should not retry for an error other than ECONNRESET', () => {
+      nock(baseUrl)
+        .get('/')
+        .replyWithError({
+          response: { status: 500 }
+        })
+
+      return expect(client.get('/')).to.be.rejected.then(error => {
+        expect(error.errorCode).to.equal(500)
+        sinon.assert.calledOnce(requestStartSpy)
+        sinon.assert.calledOnce(requestFailureSpy)
+        expect(requestFailureSpy.getCall(0).args.retry === undefined)
+        expect(nock.isDone()).to.eq(true)
+      })
+    })
+  })
+})

--- a/src/utils/axios-base-client.test.js
+++ b/src/utils/axios-base-client.test.js
@@ -173,8 +173,8 @@ describe('Axios base client', () => {
         })
       } catch (error) {
         expect(error.errorCode).toEqual(500)
-        requestStartSpy.mock.calls[0][0]
-        requestFailureSpy.mock.calls[0][0]
+        expect(requestStartSpy.mock.calls[0].length).toEqual(1)
+        expect(requestFailureSpy.mock.calls[0].length).toEqual(1)
         expect(requestFailureSpy.mock.calls[0][0].retryCount).toBeUndefined()
         expect(nock.isDone()).toEqual(true)
       }
@@ -194,8 +194,8 @@ describe('Axios base client', () => {
         })
       } catch (error) {
         expect(error.errorCode).toEqual(500)
-        requestStartSpy.mock.calls[0][0]
-        requestFailureSpy.mock.calls[0][0]
+        expect(requestStartSpy.mock.calls[0].length).toEqual(1)
+        expect(requestFailureSpy.mock.calls[0].length).toEqual(1)
         expect(requestFailureSpy.mock.calls[0][0].retryCount).toBeUndefined()
         expect(nock.isDone()).toEqual(true)
       }

--- a/src/utils/axios-base-client.test.js
+++ b/src/utils/axios-base-client.test.js
@@ -56,7 +56,7 @@ describe('Axios base client', () => {
       })
     })
 
-    it('should throw error and call failure hook on 400 response', () => {
+    it('should throw error and call failure hook on 400 response', async () => {
       const body = {
         error_identifier: 'AN-ERROR',
         message: 'a-message',
@@ -66,32 +66,34 @@ describe('Axios base client', () => {
         .get('/')
         .reply(400, body)
 
-      return expect(client.get('/', 'doing something', {
-        additionalLoggingFields: { foo: 'bar' }
-      })).to.be.rejected.then((error) => {
-        expect(error.message).to.equal('a-message')
-        expect(error.errorCode).to.equal(400)
-        expect(error.errorIdentifier).to.equal('AN-ERROR')
-        expect(error.service).to.equal(app)
-
-        sinon.assert.calledWith(requestFailureSpy, {
-          service: app,
-          responseTime: sinon.match.number,
-          method: 'get',
-          params: undefined,
-          status: 400,
-          url: '/',
-          code: 400,
-          errorIdentifier: body.error_identifier,
-          reason: 'something',
-          message: body.message,
-          description: 'doing something',
+      try {
+        await client.get('/', 'doing something', {
           additionalLoggingFields: { foo: 'bar' }
         })
+      } catch (error) {
+        expect(error.message).toEqual('a-message')
+        expect(error.errorCode).toEqual(400)
+        expect(error.errorIdentifier).toEqual('AN-ERROR')
+        expect(error.service).toEqual(app)
+      }
+
+      expect(requestFailureSpy.mock.calls[0][0]).toEqual({
+        service: app,
+        responseTime: expect.any(Number),
+        method: 'get',
+        params: undefined,
+        status: 400,
+        url: '/',
+        code: 400,
+        errorIdentifier: body.error_identifier,
+        reason: 'something',
+        message: body.message,
+        description: 'doing something',
+        additionalLoggingFields: { foo: 'bar' }
       })
     })
 
-    it('should throw error and call failure hook on 500 response', () => {
+    it('should throw error and call failure hook on 500 response', async () => {
       const body = {
         error_identifier: 'AN-ERROR',
         message: 'a-message',
@@ -101,34 +103,36 @@ describe('Axios base client', () => {
         .get('/')
         .reply(500, body)
 
-      return expect(client.get('/', 'doing something', {
-        additionalLoggingFields: { foo: 'bar' }
-      })).to.be.rejected.then((error) => {
-        expect(error.message).to.equal('a-message')
-        expect(error.errorCode).to.equal(500)
-        expect(error.errorIdentifier).to.equal('AN-ERROR')
-        expect(error.service).to.equal(app)
-
-        sinon.assert.calledWith(requestFailureSpy, {
-          service: app,
-          responseTime: sinon.match.number,
-          method: 'get',
-          params: undefined,
-          status: 500,
-          url: '/',
-          code: 500,
-          errorIdentifier: body.error_identifier,
-          reason: 'something',
-          message: body.message,
-          description: 'doing something',
+      try {
+        await client.get('/', 'doing something', {
           additionalLoggingFields: { foo: 'bar' }
         })
+      } catch (error) {
+        expect(error.message).toEqual('a-message')
+        expect(error.errorCode).toEqual(500)
+        expect(error.errorIdentifier).toEqual('AN-ERROR')
+        expect(error.service).toEqual(app)
+      }
+
+      expect(requestFailureSpy.mock.calls[0][0]).toEqual({
+        service: app,
+        responseTime: expect.any(Number),
+        method: 'get',
+        params: undefined,
+        status: 500,
+        url: '/',
+        code: 500,
+        errorIdentifier: body.error_identifier,
+        reason: 'something',
+        message: body.message,
+        description: 'doing something',
+        additionalLoggingFields: { foo: 'bar' }
       })
     })
   })
 
   describe('Retries', () => {
-    it('should retry GET request 3 times when ECONNRESET error thrown', () => {
+    it('should retry GET request 3 times when ECONNRESET error thrown', async () => {
       nock(baseUrl)
         .get('/')
         .times(3)
@@ -137,30 +141,25 @@ describe('Axios base client', () => {
           response: { status: 500 }
         })
 
-      return expect(client.get('/', 'foo')).to.be.rejected.then(error => {
-        expect(error.errorCode).to.equal(500)
-        sinon.assert.calledThrice(requestStartSpy)
-        requestStartSpy.getCall(0).calledWithMatch({
-          method: 'get',
-          url: '/'
+      try {
+        await client.get('/', 'foo', {
+          additionalLoggingFields: { foo: 'bar' }
         })
-        requestStartSpy.getCall(1).calledWithMatch({
-          method: 'get',
-          url: '/',
-          retryCount: 2
-        })
-        requestStartSpy.getCall(2).calledWithMatch({
+      } catch (error) {
+        expect(error.errorCode).toEqual(500)
+        expect(requestStartSpy.mock.calls.length).toEqual(3)
+        expect(requestStartSpy.mock.calls[0][0]).toEqual({
+          service: 'an-app',
           method: 'get',
           url: '/',
-          retryCount: 3
+          description: 'foo',
+          additionalLoggingFields: { foo: 'bar' }
         })
-        sinon.assert.calledThrice(requestFailureSpy)
-        sinon.assert.calledWithMatch(requestFailureSpy, { retry: true })
-        expect(nock.isDone()).to.eq(true)
-      })
+        expect(nock.isDone()).toEqual(true)
+      }
     })
 
-    it('should not retry POST requests when ECONNRESET error returned', () => {
+    it('should not retry POST requests when ECONNRESET error returned', async () => {
       nock(baseUrl)
         .post('/')
         .replyWithError({
@@ -168,29 +167,38 @@ describe('Axios base client', () => {
           response: { status: 500 }
         })
 
-      return expect(client.post('/')).to.be.rejected.then(error => {
-        expect(error.errorCode).to.equal(500)
-        sinon.assert.calledOnce(requestStartSpy)
-        sinon.assert.calledOnce(requestFailureSpy)
-        expect(requestFailureSpy.getCall(0).args.retry === undefined)
-        expect(nock.isDone()).to.eq(true)
-      })
+      try {
+        await client.post('/', 'foo', {
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      } catch (error) {
+        expect(error.errorCode).toEqual(500)
+        requestStartSpy.mock.calls[0][0]
+        requestFailureSpy.mock.calls[0][0]
+        expect(requestFailureSpy.mock.calls[0][0].retryCount).toBeUndefined()
+        expect(nock.isDone()).toEqual(true)
+      }
+
     })
 
-    it('should not retry for an error other than ECONNRESET', () => {
+    it('should not retry for an error other than ECONNRESET', async () => {
       nock(baseUrl)
         .get('/')
         .replyWithError({
           response: { status: 500 }
         })
 
-      return expect(client.get('/')).to.be.rejected.then(error => {
-        expect(error.errorCode).to.equal(500)
-        sinon.assert.calledOnce(requestStartSpy)
-        sinon.assert.calledOnce(requestFailureSpy)
-        expect(requestFailureSpy.getCall(0).args.retry === undefined)
-        expect(nock.isDone()).to.eq(true)
-      })
+      try {
+        await client.get('/', 'foo', {
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      } catch (error) {
+        expect(error.errorCode).toEqual(500)
+        requestStartSpy.mock.calls[0][0]
+        requestFailureSpy.mock.calls[0][0]
+        expect(requestFailureSpy.mock.calls[0][0].retryCount).toBeUndefined()
+        expect(nock.isDone()).toEqual(true)
+      }
     })
   })
 })

--- a/src/utils/axios-base-client.test.js
+++ b/src/utils/axios-base-client.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 'use strict'
 
 const nock = require('nock')

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,40 @@
+'use strict'
+
+class RESTClientError extends Error {
+  constructor (message, service, errorCode, errorIdentifier, reason) {
+    super(message)
+    this.name = this.constructor.name
+    this.service = service
+    this.errorCode = errorCode
+    this.errorIdentifier = errorIdentifier
+    this.reason = reason
+  }
+}
+
+class DomainError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+class NotFoundError extends DomainError {
+}
+
+class AccountCannotTakePaymentsError extends DomainError {
+}
+
+class InvalidPrefilledAmountError extends DomainError {
+}
+
+class InvalidPrefilledReferenceError extends DomainError {
+}
+
+module.exports = {
+  RESTClientError,
+  NotFoundError,
+  AccountCannotTakePaymentsError,
+  InvalidPrefilledAmountError,
+  InvalidPrefilledReferenceError
+}

--- a/src/utils/errors.test.js
+++ b/src/utils/errors.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const { expect } = require('chai')
+const { NotAuthenticatedError, UserAccountDisabledError, NotAuthorisedError, NotFoundError, RESTClientError} = require('./errors')
+
+describe('Error classes', () => {
+  it('should construct NotAuthenticatedError', () => {
+    const error = new NotAuthenticatedError('not authenticated')
+    expect(error.message).to.equal('not authenticated')
+    expect(error.name).to.equal('NotAuthenticatedError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct UserAccountDisabledError', () => {
+    const error = new UserAccountDisabledError('user disabled')
+    expect(error.message).to.equal('user disabled')
+    expect(error.name).to.equal('UserAccountDisabledError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct NotAuthorisedError', () => {
+    const error = new NotAuthorisedError('not authorised')
+    expect(error.message).to.equal('not authorised')
+    expect(error.name).to.equal('NotAuthorisedError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct NotFoundError', () => {
+    const error = new NotFoundError('not found')
+    expect(error.message).to.equal('not found')
+    expect(error.name).to.equal('NotFoundError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct RESTClientError', () => {
+    const error = new RESTClientError('client error')
+    expect(error.message).to.equal('client error')
+    expect(error.name).to.equal('RESTClientError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+})

--- a/src/utils/errors.test.js
+++ b/src/utils/errors.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { expect } = require('chai')
-const { NotAuthenticatedError, UserAccountDisabledError, NotAuthorisedError, NotFoundError, RESTClientError} = require('./errors')
+const { NotAuthenticatedError, UserAccountDisabledError, NotAuthorisedError, NotFoundError, RESTClientError } = require('./errors')
 
 describe('Error classes', () => {
   it('should construct NotAuthenticatedError', () => {


### PR DESCRIPTION
Products-ui: replace `request` library with `axios`

https://payments-platform.atlassian.net/browse/PP-11683

**Summary of changes**

- Add new version of base client script using ‘axios’ instead of ‘request’ library.
- Add common module containing ‘RESTClientError’ and base type ‘DomainError’ classes required by `axios-base-client.js`.
- Update `package.json` with axios dependency.
