### PR TITLE
Pp 11683 add axios base client and karma test updates

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,12 @@ module.exports = karma => karma.set({
   ],
   files: [
     'index.js',
-    '!(analytics)**/**/*.js'
+    '**/**/**.js'
+  ],
+  exclude: [
+    '**/axios-base-client.test.js',
+    'analytics/**/*.js',
+    '**/errors.test.js'
   ],
   plugins: [
     'karma-mocha',
@@ -20,7 +25,14 @@ module.exports = karma => karma.set({
   ],
   browserify: {
     debug: true, // Gets us source-maps, which in turn gets us human-readable error stacks in tests
-    transform: [['babelify']]
+    transform: [[
+      'babelify',
+      {
+        global: true,
+        presets: ['@babel/preset-env']
+      }
+    ]
+    ]
   },
   preprocessors: {
     '**/*.js': [ 'browserify' ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.0.13",
       "license": "MIT",
       "dependencies": {
+        "axios": "^1.6.5",
         "lodash": "4.17.21",
         "moment-timezone": "0.5.43",
         "rfc822-validate": "1.0.0",
@@ -39,6 +40,7 @@
         "karma-source-map-support": "^1.2.0",
         "lint-staged": "^13.0.1",
         "mocha": "^10.0.0",
+        "nock": "^13.5.1",
         "sinon": "^15.0.0",
         "standard": "^17.0.0",
         "uglify-js": "^3.6.0",
@@ -3877,8 +3879,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -3906,6 +3907,29 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
+    },
+    "node_modules/axios": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.6.0",
@@ -5046,7 +5070,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5573,7 +5596,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7840,7 +7862,6 @@
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
       "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -12905,7 +12926,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12914,7 +12934,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -13489,6 +13508,37 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.1.tgz",
+      "integrity": "sha512-+s7b73fzj5KnxbKH4Oaqz07tQ8degcMilU4rrmnKvI//b0JMBU4wEXFQ8zqr+3+L4eWSfU3H/UoIVGUV0tue1Q==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/nock/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-int64": {
@@ -14391,6 +14441,15 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/proto-props": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/proto-props/-/proto-props-2.0.0.tgz",
@@ -14399,6 +14458,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -21214,8 +21278,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -21234,6 +21297,28 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "requires": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "babel-jest": {
       "version": "29.6.0",
@@ -22153,7 +22238,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -22599,8 +22683,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "2.0.0",
@@ -24309,8 +24392,7 @@
     "follow-redirects": {
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
-      "dev": true
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -28026,14 +28108,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -28472,6 +28552,28 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "nock": {
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.1.tgz",
+      "integrity": "sha512-+s7b73fzj5KnxbKH4Oaqz07tQ8degcMilU4rrmnKvI//b0JMBU4wEXFQ8zqr+3+L4eWSfU3H/UoIVGUV0tue1Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "node-int64": {
@@ -29138,11 +29240,22 @@
         }
       }
     },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
+    },
     "proto-props": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/proto-props/-/proto-props-2.0.0.tgz",
       "integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
       "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "npm run transpile && npm run browserify-analytics",
     "test": "npm run jest-tests npm && npm run karma-tests",
     "karma-tests": "karma start",
-    "jest-tests": "jest src/analytics",
+    "jest-tests": "jest src/analytics src/utils/axios-base-client/axios-base-client.test.js",
     "lint": "standard --fix"
   },
   "repository": {
@@ -132,6 +132,7 @@
     "karma-source-map-support": "^1.2.0",
     "lint-staged": "^13.0.1",
     "mocha": "^10.0.0",
+    "nock": "^13.5.1",
     "sinon": "^15.0.0",
     "standard": "^17.0.0",
     "uglify-js": "^3.6.0",
@@ -142,6 +143,7 @@
     "lib": "lib"
   },
   "dependencies": {
+    "axios": "^1.6.5",
     "lodash": "4.17.21",
     "moment-timezone": "0.5.43",
     "rfc822-validate": "1.0.0",

--- a/src/utils/axios-base-client/axios-base-client.js
+++ b/src/utils/axios-base-client/axios-base-client.js
@@ -1,0 +1,146 @@
+'use strict'
+
+const http = require('http')
+const https = require('https')
+const axios = require('axios')
+const { RESTClientError } = require('./errors')
+
+class Client {
+  constructor (app) {
+    this._app = app
+  }
+
+  /**
+   * Configure the client. Should only be called once.
+   */
+  configure (baseURL, options) {
+    this._axios = axios.create({
+      baseURL,
+      timeout: 60 * 1000,
+      maxContentLength: 50 * 1000 * 1000,
+      httpAgent: new http.Agent({
+        keepAlive: true
+      }),
+      httpsAgent: new https.Agent({
+        keepAlive: true,
+        rejectUnauthorized: process.env.NODE_ENV === 'production'
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+    })
+
+    this._axios.interceptors.request.use(config => {
+      const requestContext = {
+        service: this._app,
+        method: config.method,
+        url: config.url,
+        description: config.description,
+        additionalLoggingFields: config.additionalLoggingFields,
+        ...config.retryCount && { retryCount: config.retryCount }
+      }
+      if (options.onRequestStart) {
+        options.onRequestStart(requestContext)
+      }
+
+      const headers = options.transformRequestAddHeaders ? options.transformRequestAddHeaders() : {}
+      Object.entries(headers)
+        .forEach(([headerKey, headerValue]) => {
+          config.headers[headerKey] = headerValue
+        })
+
+      return {
+        ...config,
+        metadata: { start: Date.now() }
+      }
+    })
+
+    this._axios.interceptors.response.use((response) => {
+      const responseContext = {
+        service: this._app,
+        responseTime: Date.now() - (response.config).metadata.start,
+        method: response.config.method,
+        params: response.config.params,
+        status: response.status,
+        url: response.config.url,
+        description: response.config.description,
+        additionalLoggingFields: response.config.additionalLoggingFields
+      }
+      if (options.onSuccessResponse) {
+        options.onSuccessResponse(responseContext)
+      }
+      return response
+    }, async (error) => {
+      const config = error.config || {}
+      let errors = error.response.data && (error.response.data.message || error.response.data.errors)
+      if (errors && Array.isArray(errors)) {
+        errors = errors.join(', ')
+      }
+      const errorContext = {
+        service: this._app,
+        responseTime: Date.now() - (config.metadata && config.metadata.start),
+        method: config.method,
+        params: config.params,
+        status: error.response && error.response.status,
+        url: config.url,
+        code: (error.response && error.response.status) || error.code,
+        errorIdentifier: error.response && error.response.data && error.response.data.error_identifier,
+        reason: error.response && error.response.data && error.response.data.reason,
+        message: errors || error.response.data || 'Unknown error',
+        description: config.description,
+        additionalLoggingFields: config.additionalLoggingFields
+      }
+
+      // TODO: could use axios-retry to achieve this if desired
+      // Retry ECONNRESET errors for GET requests 3 times in total
+      if (config.method === 'get' && error.code === 'ECONNRESET') {
+        const retryCount = config.retryCount || 0
+        if (retryCount < 2) {
+          config.retryCount = retryCount + 1
+          if (options.onFailureResponse) {
+            errorContext.retry = true
+            options.onFailureResponse(errorContext)
+          }
+          await new Promise(resolve => setTimeout(resolve, 500))
+          return this._axios(config)
+        }
+      }
+      if (options.onFailureResponse) {
+        options.onFailureResponse(errorContext)
+      }
+      throw new RESTClientError(errorContext.message, errorContext.service, errorContext.status, errorContext.errorIdentifier, errorContext.reason)
+    })
+  }
+
+  _getConfigWithDescription (config = {}, description) {
+    return {
+      ...config,
+      description
+    }
+  }
+
+  get (url, description, config) {
+    return this._axios.get(url, this._getConfigWithDescription(config, description))
+  }
+
+  post (url, payload, description, config) {
+    return this._axios.post(url, payload, this._getConfigWithDescription(config, description))
+  }
+
+  put (url, payload, description, config) {
+    return this._axios.put(url, payload, this._getConfigWithDescription(config, description))
+  }
+
+  patch (url, payload, description, config) {
+    return this._axios.patch(url, payload, this._getConfigWithDescription(config, description))
+  }
+
+  delete (url, description, config) {
+    return this._axios.delete(url, this._getConfigWithDescription(config, description))
+  }
+}
+
+module.exports = {
+  Client
+}

--- a/src/utils/axios-base-client/axios-base-client.test.js
+++ b/src/utils/axios-base-client/axios-base-client.test.js
@@ -1,0 +1,204 @@
+'use strict'
+
+const nock = require('nock')
+const { Client } = require('./axios-base-client')
+
+const baseUrl = 'http://localhost:8000'
+const app = 'an-app'
+
+describe('Axios base client', () => {
+  const requestStartSpy = jest.fn()
+  const requestSuccessSpy = jest.fn()
+  const requestFailureSpy = jest.fn()
+  const client = new Client(app)
+  client.configure(baseUrl, {
+    onRequestStart: requestStartSpy,
+    onSuccessResponse: requestSuccessSpy,
+    onFailureResponse: requestFailureSpy
+  })
+
+  beforeEach(() => {
+    requestStartSpy.mockClear()
+    requestFailureSpy.mockClear()
+    requestSuccessSpy.mockClear()
+  })
+
+  describe('Response and hooks', () => {
+    it('should return response and call success hook on 200 response', async () => {
+      const body = { foo: 'bar' }
+      nock(baseUrl)
+        .get('/')
+        .reply(200, body)
+
+      const response = await client.get('/', 'doing something', {
+        additionalLoggingFields: { foo: 'bar' }
+      })
+
+      expect(response.data).toEqual(body)
+
+      expect(requestStartSpy.mock.calls[0][0]).toEqual({
+        service: app,
+        method: 'get',
+        url: '/',
+        description: 'doing something',
+        additionalLoggingFields: { foo: 'bar' }
+      })
+
+      expect(requestSuccessSpy.mock.calls[0][0]).toEqual({
+        service: app,
+        responseTime: expect.any(Number),
+        method: 'get',
+        params: undefined,
+        status: 200,
+        url: '/',
+        description: 'doing something',
+        additionalLoggingFields: { foo: 'bar' }
+      })
+    })
+
+    it('should throw error and call failure hook on 400 response', async () => {
+      const body = {
+        error_identifier: 'AN-ERROR',
+        message: 'a-message',
+        reason: 'something'
+      }
+      nock(baseUrl)
+        .get('/')
+        .reply(400, body)
+
+      try {
+        await client.get('/', 'doing something', {
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      } catch (error) {
+        expect(error.message).toEqual('a-message')
+        expect(error.errorCode).toEqual(400)
+        expect(error.errorIdentifier).toEqual('AN-ERROR')
+        expect(error.service).toEqual(app)
+      }
+
+      expect(requestFailureSpy.mock.calls[0][0]).toEqual({
+        service: app,
+        responseTime: expect.any(Number),
+        method: 'get',
+        params: undefined,
+        status: 400,
+        url: '/',
+        code: 400,
+        errorIdentifier: body.error_identifier,
+        reason: 'something',
+        message: body.message,
+        description: 'doing something',
+        additionalLoggingFields: { foo: 'bar' }
+      })
+    })
+
+    it('should throw error and call failure hook on 500 response', async () => {
+      const body = {
+        error_identifier: 'AN-ERROR',
+        message: 'a-message',
+        reason: 'something'
+      }
+      nock(baseUrl)
+        .get('/')
+        .reply(500, body)
+
+      try {
+        await client.get('/', 'doing something', {
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      } catch (error) {
+        expect(error.message).toEqual('a-message')
+        expect(error.errorCode).toEqual(500)
+        expect(error.errorIdentifier).toEqual('AN-ERROR')
+        expect(error.service).toEqual(app)
+      }
+
+      expect(requestFailureSpy.mock.calls[0][0]).toEqual({
+        service: app,
+        responseTime: expect.any(Number),
+        method: 'get',
+        params: undefined,
+        status: 500,
+        url: '/',
+        code: 500,
+        errorIdentifier: body.error_identifier,
+        reason: 'something',
+        message: body.message,
+        description: 'doing something',
+        additionalLoggingFields: { foo: 'bar' }
+      })
+    })
+  })
+
+  describe('Retries', () => {
+    it('should retry GET request 3 times when ECONNRESET error thrown', async () => {
+      nock(baseUrl)
+        .get('/')
+        .times(3)
+        .replyWithError({
+          code: 'ECONNRESET',
+          response: { status: 500 }
+        })
+
+      try {
+        await client.get('/', 'foo', {
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      } catch (error) {
+        expect(error.errorCode).toEqual(500)
+        expect(requestStartSpy.mock.calls.length).toEqual(3)
+        expect(requestStartSpy.mock.calls[0][0]).toEqual({
+          service: 'an-app',
+          method: 'get',
+          url: '/',
+          description: 'foo',
+          additionalLoggingFields: { foo: 'bar' }
+        })
+        expect(nock.isDone()).toEqual(true)
+      }
+    })
+
+    it('should not retry POST requests when ECONNRESET error returned', async () => {
+      nock(baseUrl)
+        .post('/')
+        .replyWithError({
+          code: 'ECONNRESET',
+          response: { status: 500 }
+        })
+
+      try {
+        await client.post('/', 'foo', {
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      } catch (error) {
+        expect(error.errorCode).toEqual(500)
+        expect(requestStartSpy.mock.calls[0].length).toEqual(1)
+        expect(requestFailureSpy.mock.calls[0].length).toEqual(1)
+        expect(requestFailureSpy.mock.calls[0][0].retryCount).toBeUndefined()
+        expect(nock.isDone()).toEqual(true)
+      }
+
+    })
+
+    it('should not retry for an error other than ECONNRESET', async () => {
+      nock(baseUrl)
+        .get('/')
+        .replyWithError({
+          response: { status: 500 }
+        })
+
+      try {
+        await client.get('/', 'foo', {
+          additionalLoggingFields: { foo: 'bar' }
+        })
+      } catch (error) {
+        expect(error.errorCode).toEqual(500)
+        expect(requestStartSpy.mock.calls[0].length).toEqual(1)
+        expect(requestFailureSpy.mock.calls[0].length).toEqual(1)
+        expect(requestFailureSpy.mock.calls[0][0].retryCount).toBeUndefined()
+        expect(nock.isDone()).toEqual(true)
+      }
+    })
+  })
+})

--- a/src/utils/axios-base-client/errors.js
+++ b/src/utils/axios-base-client/errors.js
@@ -1,0 +1,40 @@
+'use strict'
+
+class RESTClientError extends Error {
+  constructor (message, service, errorCode, errorIdentifier, reason) {
+    super(message)
+    this.name = this.constructor.name
+    this.service = service
+    this.errorCode = errorCode
+    this.errorIdentifier = errorIdentifier
+    this.reason = reason
+  }
+}
+
+class DomainError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+class NotFoundError extends DomainError {
+}
+
+class AccountCannotTakePaymentsError extends DomainError {
+}
+
+class InvalidPrefilledAmountError extends DomainError {
+}
+
+class InvalidPrefilledReferenceError extends DomainError {
+}
+
+module.exports = {
+  RESTClientError,
+  NotFoundError,
+  AccountCannotTakePaymentsError,
+  InvalidPrefilledAmountError,
+  InvalidPrefilledReferenceError
+}

--- a/src/utils/axios-base-client/errors.test.js
+++ b/src/utils/axios-base-client/errors.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const { expect } = require('chai')
+const { NotAuthenticatedError, UserAccountDisabledError, NotAuthorisedError, NotFoundError, RESTClientError} = require('./errors')
+
+describe('Error classes', () => {
+  it('should construct NotAuthenticatedError', () => {
+    const error = new NotAuthenticatedError('not authenticated')
+    expect(error.message).to.equal('not authenticated')
+    expect(error.name).to.equal('NotAuthenticatedError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct UserAccountDisabledError', () => {
+    const error = new UserAccountDisabledError('user disabled')
+    expect(error.message).to.equal('user disabled')
+    expect(error.name).to.equal('UserAccountDisabledError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct NotAuthorisedError', () => {
+    const error = new NotAuthorisedError('not authorised')
+    expect(error.message).to.equal('not authorised')
+    expect(error.name).to.equal('NotAuthorisedError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct NotFoundError', () => {
+    const error = new NotFoundError('not found')
+    expect(error.message).to.equal('not found')
+    expect(error.name).to.equal('NotFoundError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+
+  it('should construct RESTClientError', () => {
+    const error = new RESTClientError('client error')
+    expect(error.message).to.equal('client error')
+    expect(error.name).to.equal('RESTClientError')
+    expect(error.stack).to.not.be.null // eslint-disable-line
+  })
+})


### PR DESCRIPTION
- Add Axios and other related dependencies.
- Add new version of base client script using ‘axios’ instead of ‘request’ library.
- Add accompanying unit test using the Jest framework.
  - In `pay-js-commons` - we are gradually moving away from the existing
    Karma tests. Everything will be moved to Jest.
- Update Karma tests configuration
  - Make it clearer which files are excluded from Karma testing by using
    the `exclude` attribute.
  - Fix issue with Axios - use the globals=true attribute.