### PR TITLE
PP-12468 Bumping major version for HTTPS base client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Reusable js scripts for GOV.UK Pay Node.js projects
 - [Browsered scripts](#browsered-scripts)
 - [Utilities](#utilities)
 - [Nunjucks filters](#nunjucks-filters)
+- [HTTPS base client](#https-base-client)
 - [Releasing a new version](#releasing-a-new-version)
 
 ## Browsered scripts
@@ -144,9 +145,9 @@ i.e. ``< > ; : ` ( ) " \' = | , ~ [ ]``
 
 ## Utilities
 
-These are small functions that power the nunjucks filters but can also be used for server side stuff too.
-
 ### Nunjucks filters
+
+These are small functions that power the nunjucks filters but can also be used for server side stuff too.
 
 These get loaded in to the Nunjucks environment and then can apply changes to variables in templates.
 
@@ -164,6 +165,12 @@ Or a pence value can be converted to GBP
     <dd>{{ amount | penceToPounds }}</dd>
   </dl>
 ```
+
+### Https base client
+
+Used in our Node.js apps to call internal APIs such as connector or ledger.
+
+Uses the NPM Axios library.
 
 ## Releasing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "4.0.17",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-pay/pay-js-commons",
-      "version": "4.0.17",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "4.0.17",
+  "version": "5.0.0",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "engines": {
     "node": "^18.17.1"


### PR DESCRIPTION
- Contains a breaking change - the HTTPS base client is now exported in a simpler way.
- Therefore bumping major version to stop apps from auto updating to this version.