### PR TITLE
BAU custom branding ds v5 support

### DIFF
--- a/sass/custom/adur-and-worthing-council.scss
+++ b/sass/custom/adur-and-worthing-council.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/barking-havering-redbridge-nhs-trust.scss
+++ b/sass/custom/barking-havering-redbridge-nhs-trust.scss
@@ -44,6 +44,10 @@ $logo-image-width: 320px;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/bracknell-forest.scss
+++ b/sass/custom/bracknell-forest.scss
@@ -44,6 +44,10 @@ $logo-image-height: 3em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/british-pharmacopoeia.scss
+++ b/sass/custom/british-pharmacopoeia.scss
@@ -47,6 +47,12 @@ $logo-image-height: 1.5em;
     display: none;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+    float: none;
+    display: none;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/caa.scss
+++ b/sass/custom/caa.scss
@@ -44,6 +44,10 @@ $logo-image-height: 3.5em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/cadw-welsh-government-2023.scss
+++ b/sass/custom/cadw-welsh-government-2023.scss
@@ -43,6 +43,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/cadw-welsh-government.scss
+++ b/sass/custom/cadw-welsh-government.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/canterbury-city-council.scss
+++ b/sass/custom/canterbury-city-council.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/croydon-council.scss
+++ b/sass/custom/croydon-council.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/custom.scss
+++ b/sass/custom/custom.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/dacorum.scss
+++ b/sass/custom/dacorum.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/disclosure-scotland.scss
+++ b/sass/custom/disclosure-scotland.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/ea-defra.scss
+++ b/sass/custom/ea-defra.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/edinburgh-council-pest-control.scss
+++ b/sass/custom/edinburgh-council-pest-control.scss
@@ -46,6 +46,10 @@ $logo-image-width-from-tablet: 270px;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/food-standards-agency.scss
+++ b/sass/custom/food-standards-agency.scss
@@ -46,6 +46,12 @@ $logo-image-height: 1.5em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    float: right;
+    padding-top: 8px;
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/gambling-commission.scss
+++ b/sass/custom/gambling-commission.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
@@ -40,6 +40,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
@@ -46,6 +46,12 @@ $logo-image-height: 1.5em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    float: right;
+    padding-top: 8px;
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/gwent-police.scss
+++ b/sass/custom/gwent-police.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/hiw.scss
+++ b/sass/custom/hiw.scss
@@ -47,6 +47,10 @@ $logo-image-width-from-tablet: 350px;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/kcc.scss
+++ b/sass/custom/kcc.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2.5rem;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/kingston.scss
+++ b/sass/custom/kingston.scss
@@ -44,6 +44,10 @@ $logo-image-height: 4em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/lbbd.scss
+++ b/sass/custom/lbbd.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/leeds-city-council.scss
+++ b/sass/custom/leeds-city-council.scss
@@ -38,6 +38,10 @@ $logo-image-width-from-tablet: 252px;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/lewisham-and-greenwich-nhs-trust.scss
+++ b/sass/custom/lewisham-and-greenwich-nhs-trust.scss
@@ -40,6 +40,10 @@ $logo-image-width: 215px;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/london-fire-brigade.scss
+++ b/sass/custom/london-fire-brigade.scss
@@ -48,6 +48,11 @@ $logo-image-height: 1.5em;
     float: none;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+    float: none;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/merseyside-police.scss
+++ b/sass/custom/merseyside-police.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/mhra-black.scss
+++ b/sass/custom/mhra-black.scss
@@ -38,6 +38,10 @@ $logo-image-height: 1em;
     display: none;
   }
 
+  .govuk-header__service-name {
+    display: none;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/mhra.scss
+++ b/sass/custom/mhra.scss
@@ -36,6 +36,10 @@ $logo-image-height: 2em;
     display: none;
   }
 
+  .govuk-header__service-name {
+    display: none;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/ministry-of-defence-dbs-fps.scss
+++ b/sass/custom/ministry-of-defence-dbs-fps.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/national-museums-ni.scss
+++ b/sass/custom/national-museums-ni.scss
@@ -45,6 +45,10 @@ $logo-image-height: 2em;
     display: none;
   }
 
+  .govuk-header__service-name {
+    display: none;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/natural-resources-wales.scss
+++ b/sass/custom/natural-resources-wales.scss
@@ -46,6 +46,12 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    float: right;
+    padding-top: 15px;
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/neath-port-talbot-county-borough-council-2023.scss
+++ b/sass/custom/neath-port-talbot-county-borough-council-2023.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/neath_port_talbet_council.scss
+++ b/sass/custom/neath_port_talbet_council.scss
@@ -46,7 +46,7 @@ $logo-image-height: 2em;
   }
 
   .govuk-header__service-name {
-    color: $custom-text-colour;
+    display: none;
   }
 
   .govuk-header__container {

--- a/sass/custom/neath_port_talbet_council.scss
+++ b/sass/custom/neath_port_talbet_council.scss
@@ -45,6 +45,10 @@ $logo-image-height: 2em;
     display: none;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/nhs-england.scss
+++ b/sass/custom/nhs-england.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/nhsbsa.scss
+++ b/sass/custom/nhsbsa.scss
@@ -44,6 +44,10 @@ $logo-image-width: 300px;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/nibsc-standards-2023-01.scss
+++ b/sass/custom/nibsc-standards-2023-01.scss
@@ -37,6 +37,10 @@ $logo-image-height: 2em;
     display: none;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/nibsc-standards-2023-01.scss
+++ b/sass/custom/nibsc-standards-2023-01.scss
@@ -38,7 +38,7 @@ $logo-image-height: 2em;
   }
 
   .govuk-header__service-name {
-    color: $custom-text-colour;
+    display: none;
   }
 
   .govuk-header__container {

--- a/sass/custom/nibsc-standards.scss
+++ b/sass/custom/nibsc-standards.scss
@@ -37,7 +37,7 @@ $logo-image-height: 2em;
   }
 
   .govuk-header__service-name {
-    color: $custom-text-colour;
+    display: none;
   }
 
   .govuk-header__container {

--- a/sass/custom/nibsc-standards.scss
+++ b/sass/custom/nibsc-standards.scss
@@ -36,6 +36,10 @@ $logo-image-height: 2em;
     display: none;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/north-yorkshire-county-council.scss
+++ b/sass/custom/north-yorkshire-county-council.scss
@@ -36,6 +36,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/nottingham-university-hospitals-trust.scss
+++ b/sass/custom/nottingham-university-hospitals-trust.scss
@@ -44,6 +44,10 @@ $logo-image-height: 3em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/oswestry-town-council.scss
+++ b/sass/custom/oswestry-town-council.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/penzance-council.scss
+++ b/sass/custom/penzance-council.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/planning-and-building-services-edinburgh.scss
+++ b/sass/custom/planning-and-building-services-edinburgh.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/portsmouth.scss
+++ b/sass/custom/portsmouth.scss
@@ -55,6 +55,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/runnymede-borough-council.scss
+++ b/sass/custom/runnymede-borough-council.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/rushmoor.scss
+++ b/sass/custom/rushmoor.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/scottish-government-planning.scss
+++ b/sass/custom/scottish-government-planning.scss
@@ -45,6 +45,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/social-security-scotland.scss
+++ b/sass/custom/social-security-scotland.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2.5em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
     border-bottom-width: 2px;

--- a/sass/custom/someret-west-and-taunton.scss
+++ b/sass/custom/someret-west-and-taunton.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/south-wales-police.scss
+++ b/sass/custom/south-wales-police.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/stratford-upon-avon.scss
+++ b/sass/custom/stratford-upon-avon.scss
@@ -44,6 +44,10 @@ $logo-image-height: 3em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/sutton.scss
+++ b/sass/custom/sutton.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/the-coal-authority.scss
+++ b/sass/custom/the-coal-authority.scss
@@ -46,6 +46,12 @@ $logo-image-height: 1.5em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    float: right;
+    padding-top: 8px;
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/the-sixth-form-bolton.scss
+++ b/sass/custom/the-sixth-form-bolton.scss
@@ -40,6 +40,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
+++ b/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
@@ -44,6 +44,10 @@ $logo-image-height: 4em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/uk-atomic-energy-authority.scss
+++ b/sass/custom/uk-atomic-energy-authority.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
+++ b/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
@@ -36,6 +36,10 @@ $logo-image-width: 150px;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/wealden.scss
+++ b/sass/custom/wealden.scss
@@ -44,6 +44,10 @@ $logo-image-height: 3.5em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }

--- a/sass/custom/west-berkshire-council.scss
+++ b/sass/custom/west-berkshire-council.scss
@@ -44,6 +44,10 @@ $logo-image-height: 2em;
     color: $custom-text-colour;
   }
 
+  .govuk-header__service-name {
+    color: $custom-text-colour;
+  }
+
   .govuk-header__container {
     border-bottom-color: $custom-banner-border-colour;
   }


### PR DESCRIPTION
### WHAT

- add DSv5.6 specific classes to custom branding css, `frontend` is currently the only ui project to be impacted by this change so I've left the old classes in place to maintain backwards compatibility with `products-ui`