### PR TITLE
PP-13252 Remove old classnames

### DIFF
--- a/sass/custom/abuhb.scss
+++ b/sass/custom/abuhb.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/adur-and-worthing-council.scss
+++ b/sass/custom/adur-and-worthing-council.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 
@@ -54,7 +54,7 @@ $logo-image-height: 2em;
       vertical-align: bottom;
       margin-bottom: 7px;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 15px;
       float: right;
     }

--- a/sass/custom/barking-havering-redbridge-nhs-trust.scss
+++ b/sass/custom/barking-havering-redbridge-nhs-trust.scss
@@ -40,7 +40,7 @@ $logo-image-width: 320px;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/bracknell-forest.scss
+++ b/sass/custom/bracknell-forest.scss
@@ -40,7 +40,7 @@ $logo-image-height: 3em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/british-pharmacopoeia.scss
+++ b/sass/custom/british-pharmacopoeia.scss
@@ -41,7 +41,7 @@ $logo-image-height: 1.5em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
     float: none;
     display: none;
@@ -57,7 +57,7 @@ $logo-image-height: 1.5em;
       vertical-align: bottom;
       margin-bottom: 7px;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 8px;
       float: right;
     }

--- a/sass/custom/caa.scss
+++ b/sass/custom/caa.scss
@@ -40,7 +40,7 @@ $logo-image-height: 3.5em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/cadw-welsh-government-2023.scss
+++ b/sass/custom/cadw-welsh-government-2023.scss
@@ -39,7 +39,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/cadw-welsh-government.scss
+++ b/sass/custom/cadw-welsh-government.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/canterbury-city-council.scss
+++ b/sass/custom/canterbury-city-council.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/croydon-council.scss
+++ b/sass/custom/croydon-council.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/custom.scss
+++ b/sass/custom/custom.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/dacorum.scss
+++ b/sass/custom/dacorum.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/disclosure-scotland.scss
+++ b/sass/custom/disclosure-scotland.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/ea-defra.scss
+++ b/sass/custom/ea-defra.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/edinburgh-council-pest-control.scss
+++ b/sass/custom/edinburgh-council-pest-control.scss
@@ -42,7 +42,7 @@ $logo-image-width-from-tablet: 270px;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/food-standards-agency.scss
+++ b/sass/custom/food-standards-agency.scss
@@ -40,7 +40,7 @@ $logo-image-height: 1.5em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     float: right;
     padding-top: 8px;
     color: $custom-text-colour;

--- a/sass/custom/gambling-commission.scss
+++ b/sass/custom/gambling-commission.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
@@ -36,7 +36,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 
@@ -50,7 +50,7 @@ $logo-image-height: 2em;
       vertical-align: bottom;
       margin-bottom: 7px;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 15px;
       float: right;
     }
@@ -61,7 +61,7 @@ $logo-image-height: 2em;
       width: 99%;
       text-align: center;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 5px;
       float: none;
     }

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
@@ -40,7 +40,7 @@ $logo-image-height: 1.5em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     float: right;
     padding-top: 8px;
     color: $custom-text-colour;

--- a/sass/custom/gwent-police.scss
+++ b/sass/custom/gwent-police.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/hiw.scss
+++ b/sass/custom/hiw.scss
@@ -43,10 +43,6 @@ $logo-image-width-from-tablet: 350px;
     }
   }
 
-  .govuk-header__link--service-name,  {
-    color: $custom-text-colour;
-  }
-
   .govuk-header__service-name {
     color: $custom-text-colour;
   }

--- a/sass/custom/kcc.scss
+++ b/sass/custom/kcc.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2.5rem;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/kingston.scss
+++ b/sass/custom/kingston.scss
@@ -40,7 +40,7 @@ $logo-image-height: 4em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/lbbd.scss
+++ b/sass/custom/lbbd.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/leeds-city-council.scss
+++ b/sass/custom/leeds-city-council.scss
@@ -34,7 +34,7 @@ $logo-image-width-from-tablet: 252px;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/lewisham-and-greenwich-nhs-trust.scss
+++ b/sass/custom/lewisham-and-greenwich-nhs-trust.scss
@@ -36,7 +36,7 @@ $logo-image-width: 215px;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 
@@ -54,7 +54,7 @@ $logo-image-width: 215px;
       vertical-align: bottom;
       margin-bottom: 7px;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 15px;
       float: left;
     }
@@ -65,7 +65,7 @@ $logo-image-width: 215px;
       width: 99%;
       text-align: center;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 5px;
       float: none;
     }

--- a/sass/custom/london-fire-brigade.scss
+++ b/sass/custom/london-fire-brigade.scss
@@ -43,7 +43,7 @@ $logo-image-height: 1.5em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
     float: none;
   }
@@ -58,7 +58,7 @@ $logo-image-height: 1.5em;
       vertical-align: bottom;
       margin-bottom: 7px;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 9px;
       float: right;
     }

--- a/sass/custom/mhra-black.scss
+++ b/sass/custom/mhra-black.scss
@@ -34,7 +34,7 @@ $logo-image-height: 1em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     display: none;
   }
 

--- a/sass/custom/mhra.scss
+++ b/sass/custom/mhra.scss
@@ -32,7 +32,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     display: none;
   }
 

--- a/sass/custom/ministry-of-defence-dbs-fps.scss
+++ b/sass/custom/ministry-of-defence-dbs-fps.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 
@@ -54,7 +54,7 @@ $logo-image-height: 2em;
       vertical-align: bottom;
       margin-bottom: 7px;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 15px;
       float: right;
     }

--- a/sass/custom/my-university-hospitals-sussex-charity.scss
+++ b/sass/custom/my-university-hospitals-sussex-charity.scss
@@ -40,7 +40,7 @@ $logo-image-height: 4em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/national-museums-ni.scss
+++ b/sass/custom/national-museums-ni.scss
@@ -41,7 +41,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     display: none;
   }
 

--- a/sass/custom/natural-resources-wales.scss
+++ b/sass/custom/natural-resources-wales.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     float: right;
     padding-top: 15px;
     color: $custom-text-colour;

--- a/sass/custom/neath-port-talbot-county-borough-council-2023.scss
+++ b/sass/custom/neath-port-talbot-county-borough-council-2023.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/neath_port_talbet_council.scss
+++ b/sass/custom/neath_port_talbet_council.scss
@@ -41,7 +41,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     display: none;
   }
 

--- a/sass/custom/nhs-england.scss
+++ b/sass/custom/nhs-england.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/nhs-white-on-blue.scss
+++ b/sass/custom/nhs-white-on-blue.scss
@@ -5,9 +5,9 @@ $govuk-font-family: -apple-system,BlinkMacSystemFont,helvetica neue,helvetica,ub
 // Use the variables below to control the style
 // Make sure banner colours meet minimum colour contrast levels
 
-$custom-banner-colour: #ffffff;
-$custom-banner-border-colour: #0b0c0c;
-$custom-text-colour: #0b0c0c;
+$custom-banner-colour: #005eb8;
+$custom-banner-border-colour: #f0f4f5;
+$custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
 .custom-branding {

--- a/sass/custom/nhsbsa.scss
+++ b/sass/custom/nhsbsa.scss
@@ -40,7 +40,7 @@ $logo-image-width: 300px;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/nibsc-standards-2023-01.scss
+++ b/sass/custom/nibsc-standards-2023-01.scss
@@ -33,7 +33,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     display: none;
   }
 

--- a/sass/custom/nibsc-standards.scss
+++ b/sass/custom/nibsc-standards.scss
@@ -32,7 +32,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     display: none;
   }
 

--- a/sass/custom/north-yorkshire-county-council.scss
+++ b/sass/custom/north-yorkshire-county-council.scss
@@ -32,7 +32,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/nottingham-university-hospitals-trust.scss
+++ b/sass/custom/nottingham-university-hospitals-trust.scss
@@ -40,7 +40,7 @@ $logo-image-height: 3em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/oswestry-town-council.scss
+++ b/sass/custom/oswestry-town-council.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/penzance-council.scss
+++ b/sass/custom/penzance-council.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/planning-and-building-services-edinburgh.scss
+++ b/sass/custom/planning-and-building-services-edinburgh.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/portsmouth.scss
+++ b/sass/custom/portsmouth.scss
@@ -51,7 +51,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/runnymede-borough-council.scss
+++ b/sass/custom/runnymede-borough-council.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/rushmoor.scss
+++ b/sass/custom/rushmoor.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/scottish-government-planning.scss
+++ b/sass/custom/scottish-government-planning.scss
@@ -41,7 +41,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/social-security-scotland.scss
+++ b/sass/custom/social-security-scotland.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2.5em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/someret-west-and-taunton.scss
+++ b/sass/custom/someret-west-and-taunton.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/south-wales-police.scss
+++ b/sass/custom/south-wales-police.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/stratford-upon-avon.scss
+++ b/sass/custom/stratford-upon-avon.scss
@@ -40,7 +40,7 @@ $logo-image-height: 3em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/sutton.scss
+++ b/sass/custom/sutton.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/the-coal-authority.scss
+++ b/sass/custom/the-coal-authority.scss
@@ -40,7 +40,7 @@ $logo-image-height: 1.5em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     float: right;
     padding-top: 8px;
     color: $custom-text-colour;

--- a/sass/custom/the-sixth-form-bolton.scss
+++ b/sass/custom/the-sixth-form-bolton.scss
@@ -36,7 +36,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 
@@ -50,7 +50,7 @@ $logo-image-height: 2em;
       vertical-align: bottom;
       margin-bottom: 7px;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 15px;
     }
   }
@@ -60,7 +60,7 @@ $logo-image-height: 2em;
       width: 99%;
       text-align: center;
     }
-    .govuk-header__link--service-name, .govuk-header__service-name {
+    .govuk-header__service-name {
       padding-top: 5px;
       float: none;
     }

--- a/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
+++ b/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
@@ -40,7 +40,7 @@ $logo-image-height: 4em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/uk-atomic-energy-authority.scss
+++ b/sass/custom/uk-atomic-energy-authority.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
+++ b/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
@@ -32,7 +32,7 @@ $logo-image-width: 150px;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/university-hospitals-sussex.scss
+++ b/sass/custom/university-hospitals-sussex.scss
@@ -40,7 +40,7 @@ $logo-image-height: 4em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/wealden.scss
+++ b/sass/custom/wealden.scss
@@ -40,7 +40,7 @@ $logo-image-height: 3.5em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 

--- a/sass/custom/west-berkshire-council.scss
+++ b/sass/custom/west-berkshire-council.scss
@@ -40,7 +40,7 @@ $logo-image-height: 2em;
     }
   }
 
-  .govuk-header__link--service-name, .govuk-header__service-name {
+  .govuk-header__service-name {
     color: $custom-text-colour;
   }
 


### PR DESCRIPTION
- We can remove `govuk-header__link--service-name` as this was removed from govuk-frontend v5.
- This class has been replaced with `govuk-header__service-name` which was already added as part of an older PR: https://github.com/alphagov/pay-js-commons/pull/1290