### PR TITLE
PP-12244: Upgrade deprecated Github Actions

### DIFF
--- a/.github/workflows/prevent-merge-if-release-open.yml
+++ b/.github/workflows/prevent-merge-if-release-open.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check for unmerged release
         id: check_pr
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         env:
           THIS_PR_NUMBER: ${{ github.event.pull_request.number }}
         with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,9 +17,9 @@ jobs:
     if: "contains(github.event.head_commit.message, '[automated release]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  #v4.1.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Detect secrets
         uses: alphagov/pay-ci/actions/detect-secrets@master
   unit-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  #v4.1.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
Upgrades the following to run on Node 20:

`actions/checkout`
`actions/setup-node`
`actions/github-script`