### PR TITLE
PP-13521 Add a datetime format without seconds and timezone

### DIFF
--- a/src/nunjucks-filters/datetime.js
+++ b/src/nunjucks-filters/datetime.js
@@ -8,6 +8,8 @@ module.exports = (isoTimeString, format) => {
     formatString = 'D MMMM YYYY'
   } else if (format === 'time') {
     formatString = 'HH:mm:ss'
+  } else if (format === 'datetime') {
+    formatString = 'D MMMM YYYY HH:mm'
   }
   return moment(isoTimeString).tz('Europe/London').format(formatString)
 }

--- a/src/nunjucks-filters/datetime.test.js
+++ b/src/nunjucks-filters/datetime.test.js
@@ -12,11 +12,13 @@ describe('When an ISO timestring is passed through the  Nunjucks date/time filte
   it('it should output a human readable date', () => {
     expect(dateTimeFilter(isoDateString, 'date')).to.equal('11/12/2017')
   })
-
   it('it should output a human readable long date', () => {
     expect(dateTimeFilter(isoDateString, 'datelong')).to.equal('11 December 2017')
   })
   it('it should output a human readable time', () => {
     expect(dateTimeFilter(isoDateString, 'time')).to.equal('17:15:47')
+  })
+  it('it should output a human readable date time with no seconds or timezone', () => {
+    expect(dateTimeFilter(isoDateString, 'datetime')).to.equal('11 December 2017 17:15')
   })
 })


### PR DESCRIPTION
The webhooks events table in selfservice settings requires a date time format that isn't currently provided for by the custom nunjucks datetime formats.
- add a custom datetime format to display a datetime like `11 December 2017 17:15`