### PR TITLE
PP-13898 Update custom branding to work with new branding

### DIFF
--- a/sass/custom/abuhb.scss
+++ b/sass/custom/abuhb.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/adur-and-worthing-council.scss
+++ b/sass/custom/adur-and-worthing-council.scss
@@ -65,3 +65,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/barking-havering-redbridge-nhs-trust.scss
+++ b/sass/custom/barking-havering-redbridge-nhs-trust.scss
@@ -65,3 +65,34 @@ $logo-image-width: 320px;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/bracknell-forest.scss
+++ b/sass/custom/bracknell-forest.scss
@@ -61,3 +61,34 @@ $logo-image-height: 3em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/british-pharmacopoeia.scss
+++ b/sass/custom/british-pharmacopoeia.scss
@@ -68,3 +68,34 @@ $logo-image-height: 1.5em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/caa.scss
+++ b/sass/custom/caa.scss
@@ -61,3 +61,34 @@ $logo-image-height: 3.5em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/cadw-welsh-government-2023.scss
+++ b/sass/custom/cadw-welsh-government-2023.scss
@@ -60,3 +60,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/cadw-welsh-government.scss
+++ b/sass/custom/cadw-welsh-government.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/canterbury-city-council.scss
+++ b/sass/custom/canterbury-city-council.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/cardiff-and-vale-uhb.scss
+++ b/sass/custom/cardiff-and-vale-uhb.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/croydon-council.scss
+++ b/sass/custom/croydon-council.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/custom.scss
+++ b/sass/custom/custom.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/cypress-testing-purple-background.scss
+++ b/sass/custom/cypress-testing-purple-background.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/cypress-testing-white-background.scss
+++ b/sass/custom/cypress-testing-white-background.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/dacorum.scss
+++ b/sass/custom/dacorum.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/disclosure-scotland.scss
+++ b/sass/custom/disclosure-scotland.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/dvsa-nidirect.scss
+++ b/sass/custom/dvsa-nidirect.scss
@@ -61,3 +61,34 @@ $logo-image-height: 32px;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/ea-defra.scss
+++ b/sass/custom/ea-defra.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/edevelopment-scot.scss
+++ b/sass/custom/edevelopment-scot.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/edinburgh-council-pest-control.scss
+++ b/sass/custom/edinburgh-council-pest-control.scss
@@ -66,3 +66,34 @@ $logo-image-width-from-tablet: 270px;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/food-standards-agency.scss
+++ b/sass/custom/food-standards-agency.scss
@@ -63,3 +63,34 @@ $logo-image-height: 1.5em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/gambling-commission.scss
+++ b/sass/custom/gambling-commission.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
@@ -72,3 +72,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
@@ -63,3 +63,34 @@ $logo-image-height: 1.5em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/gwent-police.scss
+++ b/sass/custom/gwent-police.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/hiw.scss
+++ b/sass/custom/hiw.scss
@@ -72,3 +72,34 @@ $logo-image-width-from-tablet: 350px;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/hssib.scss
+++ b/sass/custom/hssib.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/kcc.scss
+++ b/sass/custom/kcc.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2.5rem;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/kingston.scss
+++ b/sass/custom/kingston.scss
@@ -61,3 +61,34 @@ $logo-image-height: 4em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/lbbd.scss
+++ b/sass/custom/lbbd.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/leeds-city-council.scss
+++ b/sass/custom/leeds-city-council.scss
@@ -62,3 +62,34 @@ $logo-image-width-from-tablet: 252px;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/lewisham-and-greenwich-nhs-trust.scss
+++ b/sass/custom/lewisham-and-greenwich-nhs-trust.scss
@@ -76,3 +76,34 @@ $logo-image-width: 215px;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/london-fire-brigade.scss
+++ b/sass/custom/london-fire-brigade.scss
@@ -69,3 +69,34 @@ $logo-image-height: 1.5em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/merseyside-police.scss
+++ b/sass/custom/merseyside-police.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/mhra-black.scss
+++ b/sass/custom/mhra-black.scss
@@ -59,3 +59,34 @@ $logo-image-height: 1em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/mhra.scss
+++ b/sass/custom/mhra.scss
@@ -53,3 +53,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/ministry-of-defence-dbs-fps.scss
+++ b/sass/custom/ministry-of-defence-dbs-fps.scss
@@ -65,3 +65,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/my-university-hospitals-sussex-charity.scss
+++ b/sass/custom/my-university-hospitals-sussex-charity.scss
@@ -68,3 +68,34 @@ $logo-image-height: 4em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/national-museums-ni.scss
+++ b/sass/custom/national-museums-ni.scss
@@ -62,3 +62,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/natural-resources-wales.scss
+++ b/sass/custom/natural-resources-wales.scss
@@ -63,3 +63,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/neath-port-talbot-county-borough-council-2023.scss
+++ b/sass/custom/neath-port-talbot-county-borough-council-2023.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/neath_port_talbet_council.scss
+++ b/sass/custom/neath_port_talbet_council.scss
@@ -62,3 +62,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nhs-england.scss
+++ b/sass/custom/nhs-england.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nhs-greater-manchester.scss
+++ b/sass/custom/nhs-greater-manchester.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nhs-kent-medway.scss
+++ b/sass/custom/nhs-kent-medway.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nhs-sbs.scss
+++ b/sass/custom/nhs-sbs.scss
@@ -62,3 +62,34 @@ $logo-image-width: 320px;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nhs-west-yorkshire.scss
+++ b/sass/custom/nhs-west-yorkshire.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nhs-white-on-blue.scss
+++ b/sass/custom/nhs-white-on-blue.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nhsbsa.scss
+++ b/sass/custom/nhsbsa.scss
@@ -65,3 +65,34 @@ $logo-image-width: 300px;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nibsc-standards-2023-01.scss
+++ b/sass/custom/nibsc-standards-2023-01.scss
@@ -54,3 +54,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nibsc-standards.scss
+++ b/sass/custom/nibsc-standards.scss
@@ -53,3 +53,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/north-east-derbyshire-district-council.scss
+++ b/sass/custom/north-east-derbyshire-district-council.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/north-yorkshire-council.scss
+++ b/sass/custom/north-yorkshire-council.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/north-yorkshire-county-council.scss
+++ b/sass/custom/north-yorkshire-county-council.scss
@@ -53,3 +53,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/nottingham-university-hospitals-trust.scss
+++ b/sass/custom/nottingham-university-hospitals-trust.scss
@@ -61,3 +61,34 @@ $logo-image-height: 3em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/oswestry-town-council.scss
+++ b/sass/custom/oswestry-town-council.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/penzance-council.scss
+++ b/sass/custom/penzance-council.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/planning-and-building-services-edinburgh.scss
+++ b/sass/custom/planning-and-building-services-edinburgh.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/portsmouth.scss
+++ b/sass/custom/portsmouth.scss
@@ -73,3 +73,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/registers-of-scotland.scss
+++ b/sass/custom/registers-of-scotland.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/runnymede-borough-council.scss
+++ b/sass/custom/runnymede-borough-council.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/rushmoor.scss
+++ b/sass/custom/rushmoor.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/scottish-government-planning.scss
+++ b/sass/custom/scottish-government-planning.scss
@@ -62,3 +62,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/scottish-government.scss
+++ b/sass/custom/scottish-government.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/social-security-scotland.scss
+++ b/sass/custom/social-security-scotland.scss
@@ -62,3 +62,34 @@ $logo-image-height: 2.5em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/someret-west-and-taunton.scss
+++ b/sass/custom/someret-west-and-taunton.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/south-wales-police.scss
+++ b/sass/custom/south-wales-police.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/stratford-upon-avon.scss
+++ b/sass/custom/stratford-upon-avon.scss
@@ -61,3 +61,34 @@ $logo-image-height: 3em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/sutton.scss
+++ b/sass/custom/sutton.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/the-coal-authority.scss
+++ b/sass/custom/the-coal-authority.scss
@@ -63,3 +63,34 @@ $logo-image-height: 1.5em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/the-sixth-form-bolton.scss
+++ b/sass/custom/the-sixth-form-bolton.scss
@@ -71,3 +71,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
+++ b/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
@@ -68,3 +68,34 @@ $logo-image-height: 4em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/uk-atomic-energy-authority.scss
+++ b/sass/custom/uk-atomic-energy-authority.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
+++ b/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
@@ -57,3 +57,34 @@ $logo-image-width: 150px;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/university-hospitals-sussex.scss
+++ b/sass/custom/university-hospitals-sussex.scss
@@ -68,3 +68,34 @@ $logo-image-height: 4em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/wealden.scss
+++ b/sass/custom/wealden.scss
@@ -61,3 +61,34 @@ $logo-image-height: 3.5em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+

--- a/sass/custom/west-berkshire-council.scss
+++ b/sass/custom/west-berkshire-council.scss
@@ -61,3 +61,34 @@ $logo-image-height: 2em;
     padding: .368421053em .842105263em .315789474em;
   }
 }
+
+.govuk-template--rebranded {
+  .custom-branding {
+    .govuk-header {
+      border-bottom: 10px solid #ffffff;
+    }
+
+    .govuk-header__container {
+      border-bottom: 10px solid -banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+
+    .govuk-header__link--homepage {
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }  
+
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }  
+
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+  }
+}
+


### PR DESCRIPTION
- Add CSS that will make custom branding work with the old or new branding CSS.
  - The custom branding will look the same whether the new branding is enabled or not enabled.
- Once the new branding is LIVE, we can combine the CSS and the file cleaner.
- The same bit of CSS is replicated across all the custom SASS files.