### PR TITLE
PP-13898 Custom branding CSS typo fix for new branding

### DIFF
--- a/sass/custom/abuhb.scss
+++ b/sass/custom/abuhb.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/adur-and-worthing-council.scss
+++ b/sass/custom/adur-and-worthing-council.scss
@@ -73,7 +73,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/barking-havering-redbridge-nhs-trust.scss
+++ b/sass/custom/barking-havering-redbridge-nhs-trust.scss
@@ -73,7 +73,7 @@ $logo-image-width: 320px;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/bracknell-forest.scss
+++ b/sass/custom/bracknell-forest.scss
@@ -69,7 +69,7 @@ $logo-image-height: 3em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/british-pharmacopoeia.scss
+++ b/sass/custom/british-pharmacopoeia.scss
@@ -76,7 +76,7 @@ $logo-image-height: 1.5em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/caa.scss
+++ b/sass/custom/caa.scss
@@ -69,7 +69,7 @@ $logo-image-height: 3.5em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/cadw-welsh-government-2023.scss
+++ b/sass/custom/cadw-welsh-government-2023.scss
@@ -68,7 +68,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/cadw-welsh-government.scss
+++ b/sass/custom/cadw-welsh-government.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/canterbury-city-council.scss
+++ b/sass/custom/canterbury-city-council.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/cardiff-and-vale-uhb.scss
+++ b/sass/custom/cardiff-and-vale-uhb.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/croydon-council.scss
+++ b/sass/custom/croydon-council.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/custom.scss
+++ b/sass/custom/custom.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/cypress-testing-purple-background.scss
+++ b/sass/custom/cypress-testing-purple-background.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/cypress-testing-white-background.scss
+++ b/sass/custom/cypress-testing-white-background.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/dacorum.scss
+++ b/sass/custom/dacorum.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/disclosure-scotland.scss
+++ b/sass/custom/disclosure-scotland.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/dvsa-nidirect.scss
+++ b/sass/custom/dvsa-nidirect.scss
@@ -69,7 +69,7 @@ $logo-image-height: 32px;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/ea-defra.scss
+++ b/sass/custom/ea-defra.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/edevelopment-scot.scss
+++ b/sass/custom/edevelopment-scot.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/edinburgh-council-pest-control.scss
+++ b/sass/custom/edinburgh-council-pest-control.scss
@@ -74,7 +74,7 @@ $logo-image-width-from-tablet: 270px;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/food-standards-agency.scss
+++ b/sass/custom/food-standards-agency.scss
@@ -71,7 +71,7 @@ $logo-image-height: 1.5em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/gambling-commission.scss
+++ b/sass/custom/gambling-commission.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
@@ -80,7 +80,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
@@ -71,7 +71,7 @@ $logo-image-height: 1.5em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/gwent-police.scss
+++ b/sass/custom/gwent-police.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/hiw.scss
+++ b/sass/custom/hiw.scss
@@ -80,7 +80,7 @@ $logo-image-width-from-tablet: 350px;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/hssib.scss
+++ b/sass/custom/hssib.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/kcc.scss
+++ b/sass/custom/kcc.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2.5rem;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/kingston.scss
+++ b/sass/custom/kingston.scss
@@ -69,7 +69,7 @@ $logo-image-height: 4em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/lbbd.scss
+++ b/sass/custom/lbbd.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/leeds-city-council.scss
+++ b/sass/custom/leeds-city-council.scss
@@ -70,7 +70,7 @@ $logo-image-width-from-tablet: 252px;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/lewisham-and-greenwich-nhs-trust.scss
+++ b/sass/custom/lewisham-and-greenwich-nhs-trust.scss
@@ -84,7 +84,7 @@ $logo-image-width: 215px;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/london-fire-brigade.scss
+++ b/sass/custom/london-fire-brigade.scss
@@ -77,7 +77,7 @@ $logo-image-height: 1.5em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/merseyside-police.scss
+++ b/sass/custom/merseyside-police.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/mhra-black.scss
+++ b/sass/custom/mhra-black.scss
@@ -67,7 +67,7 @@ $logo-image-height: 1em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/mhra.scss
+++ b/sass/custom/mhra.scss
@@ -61,7 +61,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/ministry-of-defence-dbs-fps.scss
+++ b/sass/custom/ministry-of-defence-dbs-fps.scss
@@ -73,7 +73,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/my-university-hospitals-sussex-charity.scss
+++ b/sass/custom/my-university-hospitals-sussex-charity.scss
@@ -76,7 +76,7 @@ $logo-image-height: 4em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/national-museums-ni.scss
+++ b/sass/custom/national-museums-ni.scss
@@ -70,7 +70,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/natural-resources-wales.scss
+++ b/sass/custom/natural-resources-wales.scss
@@ -71,7 +71,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/neath-port-talbot-county-borough-council-2023.scss
+++ b/sass/custom/neath-port-talbot-county-borough-council-2023.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/neath_port_talbet_council.scss
+++ b/sass/custom/neath_port_talbet_council.scss
@@ -70,7 +70,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nhs-england.scss
+++ b/sass/custom/nhs-england.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nhs-greater-manchester.scss
+++ b/sass/custom/nhs-greater-manchester.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nhs-kent-medway.scss
+++ b/sass/custom/nhs-kent-medway.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nhs-sbs.scss
+++ b/sass/custom/nhs-sbs.scss
@@ -70,7 +70,7 @@ $logo-image-width: 320px;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nhs-west-yorkshire.scss
+++ b/sass/custom/nhs-west-yorkshire.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nhs-white-on-blue.scss
+++ b/sass/custom/nhs-white-on-blue.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nhsbsa.scss
+++ b/sass/custom/nhsbsa.scss
@@ -73,7 +73,7 @@ $logo-image-width: 300px;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nibsc-standards-2023-01.scss
+++ b/sass/custom/nibsc-standards-2023-01.scss
@@ -62,7 +62,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nibsc-standards.scss
+++ b/sass/custom/nibsc-standards.scss
@@ -61,7 +61,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/north-east-derbyshire-district-council.scss
+++ b/sass/custom/north-east-derbyshire-district-council.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/north-yorkshire-council.scss
+++ b/sass/custom/north-yorkshire-council.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/north-yorkshire-county-council.scss
+++ b/sass/custom/north-yorkshire-county-council.scss
@@ -61,7 +61,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/nottingham-university-hospitals-trust.scss
+++ b/sass/custom/nottingham-university-hospitals-trust.scss
@@ -69,7 +69,7 @@ $logo-image-height: 3em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/oswestry-town-council.scss
+++ b/sass/custom/oswestry-town-council.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/penzance-council.scss
+++ b/sass/custom/penzance-council.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/planning-and-building-services-edinburgh.scss
+++ b/sass/custom/planning-and-building-services-edinburgh.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/portsmouth.scss
+++ b/sass/custom/portsmouth.scss
@@ -81,7 +81,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/registers-of-scotland.scss
+++ b/sass/custom/registers-of-scotland.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/runnymede-borough-council.scss
+++ b/sass/custom/runnymede-borough-council.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/rushmoor.scss
+++ b/sass/custom/rushmoor.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/scottish-government-planning.scss
+++ b/sass/custom/scottish-government-planning.scss
@@ -70,7 +70,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/scottish-government.scss
+++ b/sass/custom/scottish-government.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/social-security-scotland.scss
+++ b/sass/custom/social-security-scotland.scss
@@ -70,7 +70,7 @@ $logo-image-height: 2.5em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/someret-west-and-taunton.scss
+++ b/sass/custom/someret-west-and-taunton.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/south-wales-police.scss
+++ b/sass/custom/south-wales-police.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/stratford-upon-avon.scss
+++ b/sass/custom/stratford-upon-avon.scss
@@ -69,7 +69,7 @@ $logo-image-height: 3em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/sutton.scss
+++ b/sass/custom/sutton.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/the-coal-authority.scss
+++ b/sass/custom/the-coal-authority.scss
@@ -71,7 +71,7 @@ $logo-image-height: 1.5em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/the-sixth-form-bolton.scss
+++ b/sass/custom/the-sixth-form-bolton.scss
@@ -79,7 +79,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
+++ b/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
@@ -76,7 +76,7 @@ $logo-image-height: 4em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/uk-atomic-energy-authority.scss
+++ b/sass/custom/uk-atomic-energy-authority.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
+++ b/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
@@ -65,7 +65,7 @@ $logo-image-width: 150px;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/university-hospitals-sussex.scss
+++ b/sass/custom/university-hospitals-sussex.scss
@@ -76,7 +76,7 @@ $logo-image-height: 4em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/wealden.scss
+++ b/sass/custom/wealden.scss
@@ -69,7 +69,7 @@ $logo-image-height: 3.5em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }

--- a/sass/custom/west-berkshire-council.scss
+++ b/sass/custom/west-berkshire-council.scss
@@ -69,7 +69,7 @@ $logo-image-height: 2em;
     }
 
     .govuk-header__container {
-      border-bottom: 10px solid -banner-border-colour;
+      border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }


### PR DESCRIPTION
- Typo - was using `-banner-border-colour` instead of `$custom-banner-border-colour`
- Fixed all occurances.