### PR TITLE
Pp 14258 custom branding sass cleanup

### DIFF
--- a/sass/custom/abuhb.scss
+++ b/sass/custom/abuhb.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/adur-and-worthing-council.scss
+++ b/sass/custom/adur-and-worthing-council.scss
@@ -10,89 +10,77 @@ $custom-banner-border-colour: #066AB1;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__service-name {
-      padding-top: 15px;
-      float: right;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__service-name {
+        padding-top: 15px;
+        float: right;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/barking-havering-redbridge-nhs-trust.scss
+++ b/sass/custom/barking-havering-redbridge-nhs-trust.scss
@@ -10,89 +10,77 @@ $custom-banner-border-colour: #1d70b8;
 $custom-text-colour: #000000;
 $logo-image-width: 320px;
 
-.custom-branding {
-  @if $logo-image-width != null {
-    .custom-branding-image {
-      width: $logo-image-width;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__logo {
-      float: right;
-      margin-right: -.75rem;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-width != null {
+      .custom-branding-image {
+        width: $logo-image-width;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__logo {
+        float: right;
+        margin-right: -.75rem;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/bracknell-forest.scss
+++ b/sass/custom/bracknell-forest.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #333333;
 $custom-text-colour: #333333;
 $logo-image-height: 3em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/british-pharmacopoeia.scss
+++ b/sass/custom/british-pharmacopoeia.scss
@@ -10,92 +10,80 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 1.5em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      height: $logo-image-height;
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-    float: none;
-    display: none;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__service-name {
-      padding-top: 8px;
-      float: right;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        height: $logo-image-height;
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+      float: none;
+      display: none;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__service-name {
+        padding-top: 8px;
+        float: right;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/caa.scss
+++ b/sass/custom/caa.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 3.5em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/cadw-welsh-government-2023.scss
+++ b/sass/custom/cadw-welsh-government-2023.scss
@@ -10,84 +10,72 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/cadw-welsh-government.scss
+++ b/sass/custom/cadw-welsh-government.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-      height: $logo-image-height;
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        height: $logo-image-height;
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/canterbury-city-council.scss
+++ b/sass/custom/canterbury-city-council.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #552f54;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/cardiff-and-vale-uhb.scss
+++ b/sass/custom/cardiff-and-vale-uhb.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/croydon-council.scss
+++ b/sass/custom/croydon-council.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/custom.scss
+++ b/sass/custom/custom.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/cypress-testing-purple-background.scss
+++ b/sass/custom/cypress-testing-purple-background.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #000000;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/cypress-testing-white-background.scss
+++ b/sass/custom/cypress-testing-white-background.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #000000;
 $custom-text-colour: #000000;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/dacorum.scss
+++ b/sass/custom/dacorum.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ec6400;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/disclosure-scotland.scss
+++ b/sass/custom/disclosure-scotland.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #dfdfdf;
 $custom-text-colour: #0b0c0c;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/dvsa-nidirect.scss
+++ b/sass/custom/dvsa-nidirect.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #0a78cd;
 $custom-text-colour: #ffffff;
 $logo-image-height: 32px;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/ea-defra.scss
+++ b/sass/custom/ea-defra.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #1d70b8;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/edevelopment-scot.scss
+++ b/sass/custom/edevelopment-scot.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #0b0c0c;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/edinburgh-council-pest-control.scss
+++ b/sass/custom/edinburgh-council-pest-control.scss
@@ -12,88 +12,76 @@ $logo-image-width: 220px;
 // additional for devices from tables to bigger screens
 $logo-image-width-from-tablet: 270px;
 
-.custom-branding {
-  @if $logo-image-width != null {
-    .custom-branding-image {
-      width: $logo-image-width;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .custom-branding-image {
-      width: $logo-image-width-from-tablet;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-width != null {
+      .custom-branding-image {
+        width: $logo-image-width;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .custom-branding-image {
+        width: $logo-image-width-from-tablet;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/food-standards-agency.scss
+++ b/sass/custom/food-standards-agency.scss
@@ -10,87 +10,75 @@ $custom-banner-border-colour: #333333;
 $custom-text-colour: #333333;
 $logo-image-height: 1.5em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    float: right;
-    padding-top: 8px;
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      float: right;
+      padding-top: 8px;
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/gambling-commission.scss
+++ b/sass/custom/gambling-commission.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust-nhs-care.scss
@@ -10,96 +10,89 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link--homepage {
-    border: none;
-  }
-
-  .govuk-header__link {
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: 48em) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__service-name {
-      padding-top: 15px;
-      float: right;
-    }
-  }
-
-  @include govuk-media-query($until: 48em) {
-    .govuk-header__content {
-      width: 99%;
-      text-align: center;
-    }
-    .govuk-header__service-name {
-      padding-top: 5px;
-      float: none;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    
+    .govuk-header__link {
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: 48em) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__service-name {
+        padding-top: 15px;
+        float: right;
+      }
+    }
+    
+    @include govuk-media-query($until: 48em) {
+      .govuk-header__content {
+        width: 99%;
+        text-align: center;
+      }
+      .govuk-header__service-name {
+        padding-top: 5px;
+        float: none;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
+++ b/sass/custom/guys-and-st-thomas-nhs-foundation-trust.scss
@@ -10,87 +10,75 @@ $custom-banner-border-colour: #7F3F98;
 $custom-text-colour: #333333;
 $logo-image-height: 1.5em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    float: right;
-    padding-top: 8px;
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      float: right;
+      padding-top: 8px;
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/gwent-police.scss
+++ b/sass/custom/gwent-police.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #FBBC1B;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/hiw.scss
+++ b/sass/custom/hiw.scss
@@ -13,93 +13,81 @@ $logo-image-width: 192px;
 // additional for devices from tables to bigger screens
 $logo-image-width-from-tablet: 350px;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      width: $logo-image-width;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__logo {
-      width: 50%;
-    }
-
-    .govuk-header__content {
-      width: 50%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-
-    .custom-branding-image {
-      width: $logo-image-width-from-tablet;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        width: $logo-image-width;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__logo {
+        width: 50%;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      
+      .govuk-header__content {
+        width: 50%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
+      }
+      
+      .custom-branding-image {
+        width: $logo-image-width-from-tablet;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/hssib.scss
+++ b/sass/custom/hssib.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #194076;
 $custom-text-colour: #194076;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/kcc.scss
+++ b/sass/custom/kcc.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #103a44;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2.5rem;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/kingston.scss
+++ b/sass/custom/kingston.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #FFFFFF;
 $custom-text-colour: #FEFEFE;
 $logo-image-height: 4em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/knowsley-council.scss
+++ b/sass/custom/knowsley-council.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #eef1f2;
 $custom-text-colour: #ffffff;
 $logo-image-height: 4em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/lbbd.scss
+++ b/sass/custom/lbbd.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #555555;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/leeds-city-council.scss
+++ b/sass/custom/leeds-city-council.scss
@@ -12,84 +12,80 @@ $logo-image-width: 192px;
 // additional for devices from tables to bigger screens
 $logo-image-width-from-tablet: 252px;
 
-.custom-branding {
-  @if $logo-image-width != null {
-    .custom-branding-image {
-      width: $logo-image-width;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link {
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__logo {
-      float: right;
-      margin-right: -.75rem;
-    }
-    .custom-branding-image {
-      width: $logo-image-width-from-tablet;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-width != null {
+      .custom-branding-image {
+        width: $logo-image-width;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link {
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__logo {
+        float: right;
+        margin-right: -.75rem;
+      }
+      .custom-branding-image {
+        width: $logo-image-width-from-tablet;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/lewisham-and-greenwich-nhs-trust.scss
+++ b/sass/custom/lewisham-and-greenwich-nhs-trust.scss
@@ -10,100 +10,92 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-width: 215px;
 
-.custom-branding {
-  @if $logo-image-width != null {
-    .custom-branding-image {
-      width: $logo-image-width;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link--homepage {
-    border: none;
-  }
-
-  .govuk-header__link {
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  .govuk-header__logo {
-    float: right;
-  }
-
-  @include govuk-media-query($from: 48em) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__service-name {
-      padding-top: 15px;
-      float: left;
-    }
-  }
-
-  @include govuk-media-query($until: 48em) {
-    .govuk-header__content {
-      width: 99%;
-      text-align: center;
-    }
-    .govuk-header__service-name {
-      padding-top: 5px;
-      float: none;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-width != null {
+      .custom-branding-image {
+        width: $logo-image-width;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link {
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
-      }
-    }  
-
+    
     .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      float: right;
+    }
+    
+    @include govuk-media-query($from: 48em) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
+      }
+      .govuk-header__service-name {
+        padding-top: 15px;
+        float: left;
+      }
+    }
+    
+    @include govuk-media-query($until: 48em) {
+      .govuk-header__content {
+        width: 99%;
+        text-align: center;
+      }
+      .govuk-header__service-name {
+        padding-top: 5px;
+        float: none;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/london-fire-brigade.scss
+++ b/sass/custom/london-fire-brigade.scss
@@ -10,93 +10,81 @@ $custom-banner-border-colour: black;
 $custom-text-colour: black;
 $logo-image-height: 1.5em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      height: $logo-image-height;
-      max-height: $logo-image-height;
-      padding-top: 2px;
-      padding-bottom: 2px;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-    float: none;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__service-name {
-      padding-top: 9px;
-      float: right;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        height: $logo-image-height;
+        max-height: $logo-image-height;
+        padding-top: 2px;
+        padding-bottom: 2px;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+      float: none;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__service-name {
+        padding-top: 9px;
+        float: right;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/merseyside-police.scss
+++ b/sass/custom/merseyside-police.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #0b0c0c;
 $custom-text-colour: #0b0c0c;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/mhra-black.scss
+++ b/sass/custom/mhra-black.scss
@@ -10,83 +10,79 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 1em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      height: $logo-image-height;
-      width: 100%;
-      padding: 30px 0px;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link {
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    display: none;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__logo {
-      width: 90%;
-    }
-
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        height: $logo-image-height;
+        width: 100%;
+        padding: 30px 0px;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link {
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      display: none;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__logo {
+        width: 90%;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/mhra.scss
+++ b/sass/custom/mhra.scss
@@ -10,77 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link {
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    display: none;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link {
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      display: none;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/ministry-of-defence-dbs-fps.scss
+++ b/sass/custom/ministry-of-defence-dbs-fps.scss
@@ -10,89 +10,77 @@ $custom-banner-border-colour: #066AB1;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__service-name {
-      padding-top: 15px;
-      float: right;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__service-name {
+        padding-top: 15px;
+        float: right;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/my-university-hospitals-sussex-charity.scss
+++ b/sass/custom/my-university-hospitals-sussex-charity.scss
@@ -10,92 +10,80 @@ $custom-banner-border-colour: #1e22aa;
 $custom-text-colour: #1e22aa;
 $logo-image-height: 4em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  .govuk-header__logo {
-    float: right;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__logo {
-      margin-right: -.75rem;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
-      }
-    }  
-
+    
     .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      float: right;
+    }
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
+      }
+      .govuk-header__logo {
+        margin-right: -.75rem;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/national-museums-ni.scss
+++ b/sass/custom/national-museums-ni.scss
@@ -10,86 +10,74 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-      width: 100%;
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__logotype{
-    margin-top: 5px;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    display: none;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        width: 100%;
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__logotype{
+      margin-top: 5px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      display: none;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/natural-resources-wales.scss
+++ b/sass/custom/natural-resources-wales.scss
@@ -10,87 +10,75 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #333333;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    float: right;
-    padding-top: 15px;
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      float: right;
+      padding-top: 15px;
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/neath-port-talbot-county-borough-council-2023.scss
+++ b/sass/custom/neath-port-talbot-county-borough-council-2023.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/neath_port_talbet_council.scss
+++ b/sass/custom/neath_port_talbet_council.scss
@@ -10,86 +10,74 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #007A7C;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-      width: 100%;
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__logotype{
-    margin-top: 5px;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    display: none;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        width: 100%;
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__logotype{
+      margin-top: 5px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      display: none;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nhs-england.scss
+++ b/sass/custom/nhs-england.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #F0F4F5;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nhs-greater-manchester.scss
+++ b/sass/custom/nhs-greater-manchester.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nhs-kent-medway.scss
+++ b/sass/custom/nhs-kent-medway.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #000000;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nhs-sbs.scss
+++ b/sass/custom/nhs-sbs.scss
@@ -11,85 +11,73 @@ $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 $logo-image-width: 320px;
 
-.custom-branding {
-  @if $logo-image-width != null {
-    .custom-branding-image {
-      width: $logo-image-width;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-width != null {
+      .custom-branding-image {
+        width: $logo-image-width;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nhs-west-yorkshire.scss
+++ b/sass/custom/nhs-west-yorkshire.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nhs-white-on-blue.scss
+++ b/sass/custom/nhs-white-on-blue.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #f0f4f5;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nhsbsa.scss
+++ b/sass/custom/nhsbsa.scss
@@ -10,89 +10,77 @@ $custom-banner-border-colour: #2274B4;
 $custom-text-colour: #1D1D1B;
 $logo-image-width: 300px;
 
-.custom-branding {
-  @if $logo-image-width != null {
-    .custom-branding-image {
-      width: $logo-image-width;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__logo {
-      float: right;
-      margin-right: -.75rem;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-width != null {
+      .custom-branding-image {
+        width: $logo-image-width;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__logo {
+        float: right;
+        margin-right: -.75rem;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nibsc-standards-2023-01.scss
+++ b/sass/custom/nibsc-standards-2023-01.scss
@@ -10,78 +10,74 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      height: $logo-image-height;
-      width: 100%;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link {
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    display: none;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        height: $logo-image-height;
+        width: 100%;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link {
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      display: none;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nibsc-standards.scss
+++ b/sass/custom/nibsc-standards.scss
@@ -10,77 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link {
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    display: none;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link {
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      display: none;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/north-east-derbyshire-district-council.scss
+++ b/sass/custom/north-east-derbyshire-district-council.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #009933;
 $custom-text-colour: #000000;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/north-yorkshire-council.scss
+++ b/sass/custom/north-yorkshire-council.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/north-yorkshire-county-council.scss
+++ b/sass/custom/north-yorkshire-county-council.scss
@@ -10,77 +10,73 @@ $custom-banner-border-colour: transparent;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link {
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link {
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/nottingham-university-hospitals-trust.scss
+++ b/sass/custom/nottingham-university-hospitals-trust.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #005EB8;
 $custom-text-colour: #000;
 $logo-image-height: 3em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/oswestry-town-council.scss
+++ b/sass/custom/oswestry-town-council.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #000000;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/penzance-council.scss
+++ b/sass/custom/penzance-council.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #FECD31;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/planning-and-building-services-edinburgh.scss
+++ b/sass/custom/planning-and-building-services-edinburgh.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/portsmouth.scss
+++ b/sass/custom/portsmouth.scss
@@ -10,97 +10,85 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__logo {
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-
-  @include govuk-media-query($until: tablet) {
-    .govuk-header__logo {
-      padding-left: 5px;
-    }
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      padding-top: 15px;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__logo {
+      padding-top: 10px;
+      padding-bottom: 10px;
+    }
+    
+    @include govuk-media-query($until: tablet) {
+      .govuk-header__logo {
+        padding-left: 5px;
+      }
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        padding-top: 15px;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/registers-of-scotland.scss
+++ b/sass/custom/registers-of-scotland.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/runnymede-borough-council.scss
+++ b/sass/custom/runnymede-borough-council.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/rushmoor.scss
+++ b/sass/custom/rushmoor.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/scottish-government-planning.scss
+++ b/sass/custom/scottish-government-planning.scss
@@ -10,86 +10,74 @@ $custom-banner-border-colour: #cccccc;
 $custom-text-colour: #0b0c0c;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-      min-width: 204px;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        min-width: 204px;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/scottish-government.scss
+++ b/sass/custom/scottish-government.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #0b0c0c;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/social-security-scotland.scss
+++ b/sass/custom/social-security-scotland.scss
@@ -10,86 +10,73 @@ $custom-banner-border-colour: #e6007e;
 $custom-text-colour: #201751;
 $logo-image-height: 2.5em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-    border-bottom-width: 2px;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
-    .govuk-header__container {
-      border-bottom: 10px solid $custom-banner-border-colour;
-      margin-bottom: -10px;
-      padding-top: 10px;
-    }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
-      }
-    }  
-
+    
     .govuk-header__logo {
       margin-bottom: 10px;
       padding-top: 0;
       padding-bottom: 0;
-    }  
-
+    }
+    
     .govuk-header__service-name {
       margin: 0 0 15px;
     }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
+    .govuk-header__container {
+      border-bottom: 2px solid $custom-banner-border-colour;
+      margin-bottom: -10px;
+      padding-top: 10px;
+    }
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
+    }
   }
 }
-

--- a/sass/custom/someret-west-and-taunton.scss
+++ b/sass/custom/someret-west-and-taunton.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #07818C;
 $custom-text-colour: #0b0c0c;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/south-wales-police.scss
+++ b/sass/custom/south-wales-police.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #2F5593;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/stratford-upon-avon.scss
+++ b/sass/custom/stratford-upon-avon.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 3em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/sutton.scss
+++ b/sass/custom/sutton.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #FFFFFF;
 $custom-text-colour: #FEFEFE;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/the-coal-authority.scss
+++ b/sass/custom/the-coal-authority.scss
@@ -10,87 +10,75 @@ $custom-banner-border-colour: #333333;
 $custom-text-colour: #333333;
 $logo-image-height: 1.5em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    float: right;
-    padding-top: 8px;
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      float: right;
+      padding-top: 8px;
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/the-sixth-form-bolton.scss
+++ b/sass/custom/the-sixth-form-bolton.scss
@@ -10,95 +10,87 @@ $custom-banner-border-colour: #F8F8F8;
 $custom-text-colour: black;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link--homepage {
-    border: none;
-  }
-
-  .govuk-header__link {
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: 48em) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__service-name {
-      padding-top: 15px;
-    }
-  }
-
-  @include govuk-media-query($until: 48em) {
-    .govuk-header__content {
-      width: 99%;
-      text-align: center;
-    }
-    .govuk-header__service-name {
-      padding-top: 5px;
-      float: none;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link {
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: 48em) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__service-name {
+        padding-top: 15px;
+      }
+    }
+    
+    @include govuk-media-query($until: 48em) {
+      .govuk-header__content {
+        width: 99%;
+        text-align: center;
+      }
+      .govuk-header__service-name {
+        padding-top: 5px;
+        float: none;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
+++ b/sass/custom/torbay-south-devon-nhs-foundation-trust.scss
@@ -10,92 +10,80 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 4em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  .govuk-header__logo {
-    float: right;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__logo {
-      margin-right: -.75rem;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
-      }
-    }  
-
+    
     .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      float: right;
+    }
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
+      }
+      .govuk-header__logo {
+        margin-right: -.75rem;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/uk-atomic-energy-authority.scss
+++ b/sass/custom/uk-atomic-energy-authority.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
+++ b/sass/custom/university-hospital-southampton-nhs-foundation-trust.scss
@@ -10,81 +10,77 @@ $custom-banner-border-colour: #0072ce;
 $custom-text-colour: #000000;
 $logo-image-width: 150px;
 
-.custom-branding {
-  @if $logo-image-width != null {
-    .custom-branding-image {
-      width: $logo-image-width;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__logo {
-      float: right;
-      margin-right: -.75rem;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-width != null {
+      .custom-branding-image {
+        width: $logo-image-width;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      .govuk-header__logo {
+        float: right;
+        margin-right: -.75rem;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/university-hospitals-sussex.scss
+++ b/sass/custom/university-hospitals-sussex.scss
@@ -10,92 +10,80 @@ $custom-banner-border-colour: #ffffff;
 $custom-text-colour: #ffffff;
 $logo-image-height: 4em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  .govuk-header__logo {
-    float: right;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-    .govuk-header__logo {
-      margin-right: -.75rem;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
-      }
-    }  
-
+    
     .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+      float: right;
+    }
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
+      }
+      .govuk-header__logo {
+        margin-right: -.75rem;
+      }
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/wealden.scss
+++ b/sass/custom/wealden.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #324829;
 $custom-text-colour: #FEFEFE;
 $logo-image-height: 3.5em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-      width: 100%;
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        width: 100%;
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-

--- a/sass/custom/west-berkshire-council.scss
+++ b/sass/custom/west-berkshire-council.scss
@@ -10,85 +10,73 @@ $custom-banner-border-colour: #007046;
 $custom-text-colour: #ffffff;
 $logo-image-height: 2em;
 
-.custom-branding {
-  @if $logo-image-height != null {
-    .custom-branding-image {
-      max-height: $logo-image-height;
-
-      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        width: 100%;
-      }
-    }
-  }
-
-  .govuk-header {
-    background-color: $custom-banner-colour;
-  }
-
-  .govuk-header__link{
-    &:link,
-    &:visited {
-      color: $custom-text-colour;
-    }
-  }
-
-  .govuk-header__link--homepage {
-    &:hover,
-    &:active {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
-
-  .govuk-header__service-name {
-    color: $custom-text-colour;
-  }
-
-  .govuk-header__container {
-    border-bottom-color: $custom-banner-border-colour;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    .govuk-header__content {
-      width: 66%;
-      vertical-align: bottom;
-      margin-bottom: 7px;
-    }
-  }
-
-  .govuk-button {
-    padding: 7px 15px 6px;
-    padding: .368421053em .842105263em .315789474em;
-  }
-}
-
 .govuk-template--rebranded {
   .custom-branding {
+    @if $logo-image-height != null {
+      .custom-branding-image {
+        max-height: $logo-image-height;
+        
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          width: 100%;
+        }
+      }
+    }
+    
     .govuk-header {
+      background-color: $custom-banner-colour;
       border-bottom: 10px solid #ffffff;
     }
-
+    
+    .govuk-header__logo {
+      margin-bottom: 10px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    
+    .govuk-header__service-name {
+      margin: 0 0 15px;
+    }
+    
+    .govuk-header__link{
+      &:link,
+      &:visited {
+        color: $custom-text-colour;
+      }
+    }
+    
+    .govuk-header__link--homepage {
+      &:hover,
+      &:active {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
+      
+      &:not(:focus) {
+        background-color: transparent;
+      }
+    }
+    
+    .govuk-header__service-name {
+      color: $custom-text-colour;
+    }
+    
     .govuk-header__container {
       border-bottom: 10px solid $custom-banner-border-colour;
       margin-bottom: -10px;
       padding-top: 10px;
     }
-
-    .govuk-header__link--homepage {
-      &:not(:focus) {
-        background-color: transparent;
+    
+    @include govuk-media-query($from: tablet) {
+      .govuk-header__content {
+        width: 66%;
+        vertical-align: bottom;
+        margin-bottom: 7px;
       }
-    }  
-
-    .govuk-header__logo {
-      margin-bottom: 10px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }  
-
-    .govuk-header__service-name {
-      margin: 0 0 15px;
+    }
+    
+    .govuk-button {
+      padding: 7px 15px 6px;
+      padding: .368421053em .842105263em .315789474em;
     }
   }
 }
-


### PR DESCRIPTION
- We had 2 bits of SASS for every custom branding SASS file
  - For old branding
  - For new branding
- Now that the new branding is LIVE, we can update the SASS to take into
  account of the new branding.
- We still need to use a parent selector of `govuk-template--rebranded` -
  as this comes from the `govuk-frontend` NPM module.
  - The design system will remove this in the future as part of `govuk-frontend`
    V6.
- Some SASS files were missing some minor styling - so were updated to make them
  with the other SASS files.
- This has been tested locally trying out different custom branding.
  - Screenshots will be added to the PR.

# CAA 

<img width="677" height="387" alt="service name" src="https://github.com/user-attachments/assets/00b95221-dd0e-43cf-ae04-7baf7085ae6b" />

# Social security scotland

<img width="866" height="617" alt="Social Security Scotland" src="https://github.com/user-attachments/assets/223e4427-8d8a-433a-ae1c-792237d23adf" />

# Guys and St Thomas

<img width="866" height="617" alt="Guys and St Thomas" src="https://github.com/user-attachments/assets/37039fa0-f017-4f84-9285-731fdc4e0b45" />

# Edinburgh council

<img width="866" height="617" alt="• EDINBYRGH•" src="https://github.com/user-attachments/assets/7745a50f-7953-454b-8be7-4cd8ed427f6b" />

# HSSIB

<img width="866" height="617" alt="weath feese sate" src="https://github.com/user-attachments/assets/b2432e01-eb04-4acc-8f1d-1f0ad1bc2932" />

