### PR TITLE
PP-14242 Update the countries > translateAlpha2 function

### DIFF
--- a/src/utils/countries.js
+++ b/src/utils/countries.js
@@ -38,4 +38,12 @@ exports.govukFrontendFormatted = selectedCountry => {
   return countriesList
 }
 
-exports.translateAlpha2 = alpha2Code => countries.find(country => country.entry.country === alpha2Code).entry.name
+exports.translateAlpha2 = alpha2Code => {
+  const match = countries.find(country => country.entry.country === alpha2Code)
+
+  if (match) {
+    return match.entry.name
+  }
+
+  return null
+}

--- a/src/utils/countries.test.js
+++ b/src/utils/countries.test.js
@@ -2,28 +2,40 @@ const { expect } = require('chai')
 const countries = require('./countries')
 
 describe('countries', () => {
-  it('should list of countries ordered', () => {
-    const retrievedCountries = countries.retrieveCountries()
+  describe('retrieveCountries', () => {
+    it('should list of countries ordered', () => {
+      const retrievedCountries = countries.retrieveCountries()
 
-    expect(retrievedCountries[0].entry.country).to.eql('AF')
-    expect(retrievedCountries[1].entry.country).to.eql('AL')
+      expect(retrievedCountries[0].entry.country).to.eql('AF')
+      expect(retrievedCountries[1].entry.country).to.eql('AL')
+    })
+
+    it('should select only the correct country', () => {
+      const retrievedCountries = countries.retrieveCountries('CH')
+      const selectedCountries = retrievedCountries.filter(country => country.entry.selected === true)
+      expect(selectedCountries.length).to.be.eql(1)
+      expect(selectedCountries[0].entry.country).to.eql('CH')
+    })
+
+    it('should select GB by default', () => {
+      const retrievedCountries = countries.retrieveCountries()
+      const selectedCountries = retrievedCountries.filter(country => country.entry.selected === true)
+      expect(selectedCountries.length).to.be.eql(1)
+      expect(selectedCountries[0].entry.country).to.eql('GB')
+    })
   })
 
-  it('should translate country code to name', () => {
-    expect(countries.translateAlpha2('GB')).to.eql('United Kingdom')
-  })
+  describe('retrieveCountries', () => {
+    it('should translate country code to name', () => {
+      expect(countries.translateAlpha2('GB')).to.eql('United Kingdom')
+    })
 
-  it('should select only the correct country', () => {
-    const retrievedCountries = countries.retrieveCountries('CH')
-    const selectedCountries = retrievedCountries.filter(country => country.entry.selected === true)
-    expect(selectedCountries.length).to.be.eql(1)
-    expect(selectedCountries[0].entry.country).to.eql('CH')
-  })
+    it('should return null when an invalid country code is used', () => {
+      expect(countries.translateAlpha2('ZZ')).to.eql(null)
+    })
 
-  it('should select GB by default', () => {
-    const retrievedCountries = countries.retrieveCountries()
-    const selectedCountries = retrievedCountries.filter(country => country.entry.selected === true)
-    expect(selectedCountries.length).to.be.eql(1)
-    expect(selectedCountries[0].entry.country).to.eql('GB')
+    it('should return null when no country code is used', () => {
+      expect(countries.translateAlpha2()).to.eql(null)
+    })
   })
 })


### PR DESCRIPTION
- Update the function to handle null and invalid country codes gracefully.
- Re-organise the file to group similar tests together.