### PR TITLE
PP-14242 Update countries > translateAlpha2

### DIFF
--- a/src/utils/countries.js
+++ b/src/utils/countries.js
@@ -41,9 +41,5 @@ exports.govukFrontendFormatted = selectedCountry => {
 exports.translateAlpha2 = alpha2Code => {
   const match = countries.find(country => country.entry.country === alpha2Code)
 
-  if (match) {
-    return match.entry.name
-  }
-
-  return null
+  return match ? match.entry.name : undefined
 }

--- a/src/utils/countries.test.js
+++ b/src/utils/countries.test.js
@@ -25,17 +25,17 @@ describe('countries', () => {
     })
   })
 
-  describe('retrieveCountries', () => {
+  describe('translateAlpha2', () => {
     it('should translate country code to name', () => {
       expect(countries.translateAlpha2('GB')).to.eql('United Kingdom')
     })
 
-    it('should return null when an invalid country code is used', () => {
-      expect(countries.translateAlpha2('ZZ')).to.eql(null)
+    it('should return undefined when an invalid country code is used', () => {
+      expect(countries.translateAlpha2('ZZ')).to.eql(undefined)
     })
 
-    it('should return null when no country code is used', () => {
-      expect(countries.translateAlpha2()).to.eql(null)
+    it('should return undefined when no country code is used', () => {
+      expect(countries.translateAlpha2()).to.eql(undefined)
     })
   })
 })


### PR DESCRIPTION
- Instead of `null`, return `undefined` when something is invalid or not found.  This is more consistent with general JS standards.  Whereby an `undefined` is returned when something is not found.
- Update tests.