### PR TITLE
PP-13427 Clean up errors.test.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "npm run transpile && npm run browserify-analytics",
     "test": "npm run jest-tests npm && npm run karma-tests",
     "karma-tests": "karma start",
-    "jest-tests": "jest src/analytics src/utils/axios-base-client/axios-base-client.test.js src/utils/middleware/*.test.js",
+    "jest-tests": "jest src/analytics src/utils/axios-base-client/*.test.js src/utils/middleware/*.test.js",
     "lint": "standard --fix"
   },
   "repository": {

--- a/src/utils/axios-base-client/errors.js
+++ b/src/utils/axios-base-client/errors.js
@@ -11,30 +11,6 @@ class RESTClientError extends Error {
   }
 }
 
-class DomainError extends Error {
-  constructor (message) {
-    super(message)
-    this.name = this.constructor.name
-    Error.captureStackTrace(this, this.constructor)
-  }
-}
-
-class NotFoundError extends DomainError {
-}
-
-class AccountCannotTakePaymentsError extends DomainError {
-}
-
-class InvalidPrefilledAmountError extends DomainError {
-}
-
-class InvalidPrefilledReferenceError extends DomainError {
-}
-
 module.exports = {
-  RESTClientError,
-  NotFoundError,
-  AccountCannotTakePaymentsError,
-  InvalidPrefilledAmountError,
-  InvalidPrefilledReferenceError
+  RESTClientError
 }

--- a/src/utils/axios-base-client/errors.test.js
+++ b/src/utils/axios-base-client/errors.test.js
@@ -1,37 +1,11 @@
 'use strict'
 
 const { expect } = require('chai')
-const { NotAuthenticatedError, UserAccountDisabledError, NotAuthorisedError, NotFoundError, RESTClientError} = require('./errors')
+const { 
+  RESTClientError
+} = require('./errors')
 
 describe('Error classes', () => {
-  it('should construct NotAuthenticatedError', () => {
-    const error = new NotAuthenticatedError('not authenticated')
-    expect(error.message).to.equal('not authenticated')
-    expect(error.name).to.equal('NotAuthenticatedError')
-    expect(error.stack).to.not.be.null // eslint-disable-line
-  })
-
-  it('should construct UserAccountDisabledError', () => {
-    const error = new UserAccountDisabledError('user disabled')
-    expect(error.message).to.equal('user disabled')
-    expect(error.name).to.equal('UserAccountDisabledError')
-    expect(error.stack).to.not.be.null // eslint-disable-line
-  })
-
-  it('should construct NotAuthorisedError', () => {
-    const error = new NotAuthorisedError('not authorised')
-    expect(error.message).to.equal('not authorised')
-    expect(error.name).to.equal('NotAuthorisedError')
-    expect(error.stack).to.not.be.null // eslint-disable-line
-  })
-
-  it('should construct NotFoundError', () => {
-    const error = new NotFoundError('not found')
-    expect(error.message).to.equal('not found')
-    expect(error.name).to.equal('NotFoundError')
-    expect(error.stack).to.not.be.null // eslint-disable-line
-  })
-
   it('should construct RESTClientError', () => {
     const error = new RESTClientError('client error')
     expect(error.message).to.equal('client error')


### PR DESCRIPTION
The axios-base-client errors tests have previously been excluded when the unit tests are run. The only error class still in use is the `RESTClientError`. This remains, while all the others have been removed along with the corresponding tests. 

The test has been re-enabled by running everything within the `src/utils/axios-base-client` directory. 