### PR TITLE
PP-14403 Migrate unit tests to use Jest

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,8 +14,9 @@ module.exports = karma => karma.set({
   exclude: [
     '**/axios-base-client.test.js',
     'analytics/**/*.js',
-    'utils/middleware/**/*.js',
-    '**/errors.test.js'
+    '**/utils/**/*.js',
+    '**/errors.test.js',
+    '**/nunjucks-filters/**/*.js'
   ],
   plugins: [
     'karma-mocha',

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "npm run transpile && npm run browserify-analytics",
     "test": "npm run jest-tests npm && npm run karma-tests",
     "karma-tests": "karma start",
-    "jest-tests": "jest src/analytics src/utils/axios-base-client/*.test.js src/utils/middleware/*.test.js",
+    "jest-tests": "jest src/analytics src/utils/**.test.js src/utils/**/*.test.js src/nunjucks-filters/*.test.js",
     "lint": "standard --fix"
   },
   "repository": {

--- a/src/nunjucks-filters/country-iso-to-name.test.js
+++ b/src/nunjucks-filters/country-iso-to-name.test.js
@@ -1,10 +1,9 @@
 'use strict'
 
-const { expect } = require('chai')
 const countryISOtoName = require('./country-iso-to-name')
 
 describe('When a country ISO code is passed through the Nunjucks filter', () => {
   it('it should convert it to the full name of that country', () => {
-    expect(countryISOtoName('GB')).to.equal('United Kingdom')
+    expect(countryISOtoName('GB')).toEqual('United Kingdom')
   })
 })

--- a/src/nunjucks-filters/datetime.test.js
+++ b/src/nunjucks-filters/datetime.test.js
@@ -1,24 +1,23 @@
 'use strict'
 
-const { expect } = require('chai')
 const dateTimeFilter = require('./datetime')
 
 describe('When an ISO timestring is passed through the  Nunjucks date/time filter', () => {
   const isoDateString = '2017-12-11T17:15:47Z'
 
   it('it should output a full human readable date time', () => {
-    expect(dateTimeFilter(isoDateString, 'full')).to.equal('11 December 2017 5:15:47pm GMT')
+    expect(dateTimeFilter(isoDateString, 'full')).toEqual('11 December 2017 5:15:47pm GMT')
   })
   it('it should output a human readable date', () => {
-    expect(dateTimeFilter(isoDateString, 'date')).to.equal('11/12/2017')
+    expect(dateTimeFilter(isoDateString, 'date')).toEqual('11/12/2017')
   })
   it('it should output a human readable long date', () => {
-    expect(dateTimeFilter(isoDateString, 'datelong')).to.equal('11 December 2017')
+    expect(dateTimeFilter(isoDateString, 'datelong')).toEqual('11 December 2017')
   })
   it('it should output a human readable time', () => {
-    expect(dateTimeFilter(isoDateString, 'time')).to.equal('17:15:47')
+    expect(dateTimeFilter(isoDateString, 'time')).toEqual('17:15:47')
   })
   it('it should output a human readable date time with no seconds or timezone', () => {
-    expect(dateTimeFilter(isoDateString, 'datetime')).to.equal('11 December 2017 17:15')
+    expect(dateTimeFilter(isoDateString, 'datetime')).toEqual('11 December 2017 17:15')
   })
 })

--- a/src/nunjucks-filters/remove-indefinite-articles.test.js
+++ b/src/nunjucks-filters/remove-indefinite-articles.test.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const { expect } = require('chai')
 const removeArticles = require('./remove-indefinite-articles')
 
 describe('When a string is passed through the Nunjucks removeIndefiniteArticles filter', () => {
   it('it should remove indefinite articles (a/an)', () => {
-    expect(removeArticles('Pay for a thing')).to.equal('Pay for thing')
+    expect(removeArticles('Pay for a thing')).toEqual('Pay for thing')
   })
   it('it should remove indefinite articles (the)', () => {
-    expect(removeArticles('The Private Office of Jon Heslop')).to.equal('Private Office of Jon Heslop')
+    expect(removeArticles('The Private Office of Jon Heslop')).toEqual('Private Office of Jon Heslop')
   })
 })

--- a/src/nunjucks-filters/slugify.test.js
+++ b/src/nunjucks-filters/slugify.test.js
@@ -1,18 +1,17 @@
 'use strict'
 
-const { expect } = require('chai')
 const slugify = require('./slugify')
 
 describe('When a string is passed through the Nunjucks slugify filter', () => {
   it('it should make it url friendly', () => {
-    expect(slugify('Someönés*_+~.()\'"!:@?=,;{}/[]s string with-hyphen')).to.equal('someoness-string-with-hyphen')
+    expect(slugify('Someönés*_+~.()\'"!:@?=,;{}/[]s string with-hyphen')).toEqual('someoness-string-with-hyphen')
   })
 
   it('should replace all Welsh accented vowels with unaccented characters', () => {
-    expect(slugify('îïìíûùúüêèéëâàáäæåãôòóöœøyŷỳýÿŵẁẃẅ')).to.equal('iiiiuuuueeeeaaaaaeaaoooooeoyyyyywwww')
+    expect(slugify('îïìíûùúüêèéëâàáäæåãôòóöœøyŷỳýÿŵẁẃẅ')).toEqual('iiiiuuuueeeeaaaaaeaaoooooeoyyyyywwww')
   })
 
   it('should replace capital Welsh accented vowels with lower case unaccented characters', () => {
-    expect(slugify('ÎÏÌÍÛÙÚÜÊÈÉËÂÀÁÄÆÅÃÔÒÓÖŒØŶỲÝŸŴẀẂẄ')).to.equal('iiiiuuuueeeeaaaaaeaaoooooeoyyyywwww')
+    expect(slugify('ÎÏÌÍÛÙÚÜÊÈÉËÂÀÁÄÆÅÃÔÒÓÖŒØŶỲÝŸŴẀẂẄ')).toEqual('iiiiuuuueeeeaaaaaeaaoooooeoyyyywwww')
   })
 })

--- a/src/utils/countries.test.js
+++ b/src/utils/countries.test.js
@@ -1,4 +1,3 @@
-const { expect } = require('chai')
 const countries = require('./countries')
 
 describe('countries', () => {
@@ -6,36 +5,36 @@ describe('countries', () => {
     it('should list of countries ordered', () => {
       const retrievedCountries = countries.retrieveCountries()
 
-      expect(retrievedCountries[0].entry.country).to.eql('AF')
-      expect(retrievedCountries[1].entry.country).to.eql('AL')
+      expect(retrievedCountries[0].entry.country).toEqual('AF')
+      expect(retrievedCountries[1].entry.country).toEqual('AL')
     })
 
     it('should select only the correct country', () => {
       const retrievedCountries = countries.retrieveCountries('CH')
       const selectedCountries = retrievedCountries.filter(country => country.entry.selected === true)
-      expect(selectedCountries.length).to.be.eql(1)
-      expect(selectedCountries[0].entry.country).to.eql('CH')
+      expect(selectedCountries.length).toEqual(1)
+      expect(selectedCountries[0].entry.country).toEqual('CH')
     })
 
     it('should select GB by default', () => {
       const retrievedCountries = countries.retrieveCountries()
       const selectedCountries = retrievedCountries.filter(country => country.entry.selected === true)
-      expect(selectedCountries.length).to.be.eql(1)
-      expect(selectedCountries[0].entry.country).to.eql('GB')
+      expect(selectedCountries.length).toEqual(1)
+      expect(selectedCountries[0].entry.country).toEqual('GB')
     })
   })
 
   describe('translateAlpha2', () => {
     it('should translate country code to name', () => {
-      expect(countries.translateAlpha2('GB')).to.eql('United Kingdom')
+      expect(countries.translateAlpha2('GB')).toEqual('United Kingdom')
     })
 
     it('should return undefined when an invalid country code is used', () => {
-      expect(countries.translateAlpha2('ZZ')).to.eql(undefined)
+      expect(countries.translateAlpha2('ZZ')).toEqual(undefined)
     })
 
     it('should return undefined when no country code is used', () => {
-      expect(countries.translateAlpha2()).to.eql(undefined)
+      expect(countries.translateAlpha2()).toEqual(undefined)
     })
   })
 })

--- a/src/utils/currency-formatter.test.js
+++ b/src/utils/currency-formatter.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 // NPM dependencies
-const { expect } = require('chai')
 const {
   penceToPounds,
   poundsToPence,
@@ -19,7 +18,7 @@ const invalidAmountWithLetter = '10.50g'
 describe('Pence to pounds', () => {
   describe(`when given valid pence amount ${validPoundsAndPenceAmount}`, () => {
     it(`should return ${validPoundsAndPenceAmount}`, () => {
-      expect(penceToPounds(validPenceAmount)).to.equal(validPoundsAndPenceAmount)
+      expect(penceToPounds(validPenceAmount)).toEqual(validPoundsAndPenceAmount)
     })
   })
 })
@@ -27,7 +26,7 @@ describe('Pence to pounds', () => {
 describe('Pounds to pence', () => {
   describe(`when given valid pounds amount ${validPoundsAndPenceAmount}`, () => {
     it(`should return ${validPenceAmount}`, () => {
-      expect(poundsToPence(validPoundsAndPenceAmount)).to.equal('1050')
+      expect(poundsToPence(validPoundsAndPenceAmount)).toEqual('1050')
     })
   })
 })
@@ -35,7 +34,7 @@ describe('Pounds to pence', () => {
 describe('Pounds to pence with currency', () => {
   describe(`when given valid pence amount ${validPenceAmount}`, () => {
     it(`should return ${validPoundsAndPenceAmountWithCurrency}`, () => {
-      expect(penceToPoundsWithCurrency(validPenceAmount)).to.equal(validPoundsAndPenceAmountWithCurrency)
+      expect(penceToPoundsWithCurrency(validPenceAmount)).toEqual(validPoundsAndPenceAmountWithCurrency)
     })
   })
 })
@@ -43,25 +42,25 @@ describe('Pounds to pence with currency', () => {
 describe('Sanitise pounds and pence user input', () => {
   describe(`when given pounds and pence amount from user input ${validPoundsAndPenceAmount}`, () => {
     it(`should return ${validPenceAmount}`, () => {
-      expect(sanitisePoundsAndPenceInput(validPoundsAndPenceAmount)).to.equal(validPenceAmount)
+      expect(sanitisePoundsAndPenceInput(validPoundsAndPenceAmount)).toEqual(validPenceAmount)
     })
   })
 
   describe(`when given pounds from user input ${invalidAmountWithoutDecimals}`, () => {
     it(`should return ${validPenceAmount}`, () => {
-      expect(sanitisePoundsAndPenceInput(invalidAmountWithoutDecimals)).to.equal(1000)
+      expect(sanitisePoundsAndPenceInput(invalidAmountWithoutDecimals)).toEqual(1000)
     })
   })
 
   describe(`when given invalid pounds and pence from user input ${invalidAmountWithOneDecimals}`, () => {
     it(`should return ${validPenceAmount}`, () => {
-      expect(sanitisePoundsAndPenceInput(invalidAmountWithOneDecimals)).to.equal(validPenceAmount)
+      expect(sanitisePoundsAndPenceInput(invalidAmountWithOneDecimals)).toEqual(validPenceAmount)
     })
   })
 
   describe(`when given invalid pounds and pence from user input ${invalidAmountWithLetter}`, () => {
     it(`should return ${validPenceAmount}`, () => {
-      expect(sanitisePoundsAndPenceInput(invalidAmountWithLetter)).to.equal(validPenceAmount)
+      expect(sanitisePoundsAndPenceInput(invalidAmountWithLetter)).toEqual(validPenceAmount)
     })
   })
 })

--- a/src/utils/is-valid-email.test.js
+++ b/src/utils/is-valid-email.test.js
@@ -1,20 +1,17 @@
 'use strict'
-
-const { expect } = require('chai')
-
 const emailValidator = require('./is-valid-email')
 
 describe('When the email validation function', () => {
   describe('is passed an invalid email address', () => {
     it('should return false', () => {
-      expect(emailValidator('name@mail')).to.equal(false)
+      expect(emailValidator('name@mail')).toEqual(false)
     })
   })
   describe('is passed an a valid email address', () => {
     it('should return true', () => {
-      expect(emailValidator('name@mail.com')).to.equal(true)
-      expect(emailValidator('first.last@subdomain.mail.com')).to.equal(true)
-      expect(emailValidator('first.last@digital.cabinet-office.gov.uk')).to.equal(true)
+      expect(emailValidator('name@mail.com')).toEqual(true)
+      expect(emailValidator('first.last@subdomain.mail.com')).toEqual(true)
+      expect(emailValidator('first.last@digital.cabinet-office.gov.uk')).toEqual(true)
     })
   })
 })


### PR DESCRIPTION
- This repo uses Karma (existing tests) and Jest (used for newer tests).
- This PR updates some existing tests to use Jest.
- Updated the Karam config to ignore these files when it is running as Jest will test them instead.
- Updated the NPM Jest command to run the updated tests.
- Future PRs will migrate the remaining tests.