### PR TITLE
PP-14551 Manually bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-pay/pay-js-commons",
-  "version": "7.0.22",
+  "version": "7.0.24",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "engines": {
     "node": "^22.17.1"


### PR DESCRIPTION
- Need to manually bump version so it triggers a new automated PR to bump the version -> so we can merge that PR and automatically publish the NPM module.
- The previous automated PR was closed because it used NPM auth tokens and we have updated GHA to use OIDC.