### PR TITLE
PP-14551 GHA - Upgrade NPM when publishing to NPM

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,6 +26,8 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
           registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm # Required so we can use OIDC
+        run: npm install -g npm@11.6.0 
       - name: Install dependencies
         run: npm ci
       - name: Build project

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,8 @@
         "xo": "^0.54.0"
       },
       "engines": {
-        "node": "^22.17.1"
+        "node": "^22.17.1",
+        "npm": "^11.6.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "7.0.25",
   "description": "Reusable js scripts for GOV.UK Pay Node.js projects",
   "engines": {
-    "node": "^22.17.1"
+    "node": "^22.17.1",
+    "npm": "^11.6.0"
   },
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
- Node 22 - which is the one currently being used, comes with NPM 10.x
- To use OIDC we need NPM 11.x.
- For now, added step to upgrade NPM to 11.6.0 as part of the GHA publish workflow.
- In the future, we will upgradef the version of Node which will come bundled with NPM 11.x.